### PR TITLE
Cc add documentation

### DIFF
--- a/runtime-rust/src/components/clamp.rs
+++ b/runtime-rust/src/components/clamp.rs
@@ -44,14 +44,13 @@ impl Evaluable for proto::Clamp {
 /// # Example
 /// ```
 /// use ndarray::{ArrayD, arr2, arr1};
-/// use yarrow_runtime::utilities::transformations::{convert_to_matrix, clamp_numeric};
+/// use yarrow_runtime::components::clamp::clamp_numeric_float;
 /// let data = arr2(&[ [1.,2.,3.], [7.,11.,9.] ]).into_dyn();
-/// let mut data_2d: ArrayD<f64> = convert_to_matrix(&data);
-/// let mins: ArrayD<f64> = arr1(&[0.5,8.]).into_dyn();
-/// let maxes: ArrayD<f64> = arr1(&[2.5,10.]).into_dyn();
-/// let mut clamped_data = clamp_numeric(&data_2d, &mins, &maxes);
-/// println!("{:?}", data_2d);
-/// println!("{:?}", clamped_data);
+/// let mins: ArrayD<f64> = arr1(&[0.5, 8., 4.]).into_dyn();
+/// let maxes: ArrayD<f64> = arr1(&[2.5, 10., 12.]).into_dyn();
+///
+/// let clamped_data = clamp_numeric_float(&data, &mins, &maxes);
+/// # clamped_data.unwrap();
 /// ```
 pub fn clamp_numeric_float(
     data: &ArrayD<f64>, min: &ArrayD<f64>, max: &ArrayD<f64>

--- a/runtime-rust/src/components/mechanisms.rs
+++ b/runtime-rust/src/components/mechanisms.rs
@@ -8,6 +8,7 @@ use yarrow_validator::proto;
 
 impl Evaluable for proto::LaplaceMechanism {
     fn evaluate(&self, arguments: &NodeArguments) -> Result<Value> {
+        // read function arguments
         let epsilon: Vec<f64> = self.privacy_usage.iter()
             .map(|usage| get_epsilon(&usage))
             .collect::<Result<Vec<f64>>>()?;
@@ -59,7 +60,6 @@ impl Evaluable for proto::LaplaceMechanism {
         }
     }
 }
-
 
 impl Evaluable for proto::GaussianMechanism {
     fn evaluate(&self, arguments: &NodeArguments) -> Result<Value> {

--- a/runtime-rust/src/components/quantile.rs
+++ b/runtime-rust/src/components/quantile.rs
@@ -36,11 +36,10 @@ impl Evaluable for proto::Quantile {
 /// # Example
 /// ```
 /// use ndarray::prelude::*;
-/// use crate::components::quantile;
+/// use yarrow_runtime::components::quantile::quantile;
 /// let data: ArrayD<f64> = arr1(&[0., 1., 2., 3., 4., 5., 12., 19., 24., 90., 98., 100.]).into_dyn();
-/// let median: ArrayD<f64> = quantile(&data, &0.5);
-/// println!("{}", median);
-/// assert_eq!(median, arr1(&[8.5]).into_dyn());
+/// let median = quantile(&data, &0.5);
+/// # median.unwrap();
 /// ```
 pub fn quantile(data: &ArrayD<f64>, q: &f64) -> Result<ArrayD<f64>> {
     if &0. > q || q > &1. {

--- a/runtime-rust/src/components/resize.rs
+++ b/runtime-rust/src/components/resize.rs
@@ -26,13 +26,13 @@ impl Evaluable for proto::Resize {
     /// data in order to make it consistent with the provided `n`.
     ///
     /// # Arguments
-    /// * `data` - The data to be resized
-    /// * `n` - An estimate of the size of the data -- this could be the guess of the user, or the result of a DP release
-    /// * `distribution` - The distribution to be used when imputing records
-    /// * `min` - A lower bound on data elements
-    /// * `max` - An upper bound on data elements
-    /// * `shift` - The shift (expectation) argument for the Gaussian distribution
-    /// * `scale` - The scale (variance) argument for the Gaussian distribution
+    /// * `data` - The data to be resized.
+    /// * `n` - An estimate of the size of the data -- this could be the guess of the user, or the result of a DP release.
+    /// * `distribution` - The distribution to be used when imputing records.
+    /// * `min` - A lower bound on data elements.
+    /// * `max` - An upper bound on data elements.
+    /// * `shift` - The shift (expectation) argument for the Gaussian distribution (if used for imputation).
+    /// * `scale` - The scale (standard deviation) argument for the Gaussian distribution (if used for imputation).
     ///
     /// # Return
     /// A resized version of data consistent with the provided `n`
@@ -103,7 +103,7 @@ impl Evaluable for proto::Resize {
 /// * `min` - A lower bound on data elements
 /// * `max` - An upper bound on data elements
 /// * `shift` - The shift (expectation) argument for the Gaussian distribution
-/// * `scale` - The scale (variance) argument for the Gaussian distribution
+/// * `scale` - The scale (standard deviation) argument for the Gaussian distribution
 ///
 /// # Return
 /// A resized version of data consistent with the provided `n`
@@ -217,11 +217,12 @@ pub fn resize_categorical<T>(data: &ArrayD<T>, n: &i64,
 ///
 /// # Example
 /// ```
-/// use yarrow_runtime::src::components::resize::create_subset;
-/// let set = vec![1, 2, 3, 4, 5, 6]
-/// let weights = vec![1., 1., 1., 2., 2., 2.]
+/// use yarrow_runtime::components::resize::create_subset;
+/// let set = vec![1, 2, 3, 4, 5, 6];
+/// let weights = vec![1., 1., 1., 2., 2., 2.];
 /// let k = 3;
-/// let subset: Vec<usize> = create_subset(&set, &weights, &k)?;
+/// let subset = create_subset(&set, &weights, &k);
+/// # subset.unwrap();
 /// ```
 pub fn create_subset<T>(set: &Vec<T>, weights: &Vec<f64>, k: &i64) -> Result<Vec<T>> where T: Clone {
 
@@ -279,8 +280,9 @@ pub fn create_subset<T>(set: &Vec<T>, weights: &Vec<f64>, k: &i64) -> Result<Vec
 ///
 /// # Example
 /// ```
-/// use yarrow_runtime::src::components::resize::create_sampling_indices;
-/// let subset_indices: Vec<usize> = create_sampling_indices(&5, &10)?;
+/// use yarrow_runtime::components::resize::create_sampling_indices;
+/// let subset_indices = create_sampling_indices(&5, &10);
+/// # subset_indices.unwrap();
 /// ```
 pub fn create_sampling_indices(k: &i64, n: &i64) -> Result<Vec<usize>> {
     // create set of all indices

--- a/runtime-rust/src/components/resize.rs
+++ b/runtime-rust/src/components/resize.rs
@@ -13,7 +13,17 @@ use crate::utilities::utilities::get_num_columns;
 use crate::utilities::array::{select, stack};
 
 impl Evaluable for proto::Resize {
-    /// Testing documentation for the resize
+    /// Resizes the data in question to be consistent with a provided sample size, `n`.
+    ///
+    /// The library does not, in general, assume that the sample size of the data being
+    /// analyzed is known. This introduces a number of problems around how to calculate
+    /// statistics that are a function of the sample size.
+    ///
+    /// To address this problem, the library asks the user to provide `n`,
+    /// an estimate of the true sample size based on their own beliefs about the
+    /// data or a previous differentially private count of the number of
+    /// rows in the data. This component then either subsamples or appends to the
+    /// data in order to make it consistent with the provided `n`.
     ///
     /// # Arguments
     /// * `data` - The data to be resized

--- a/runtime-rust/src/utilities/mechanisms.rs
+++ b/runtime-rust/src/utilities/mechanisms.rs
@@ -29,7 +29,8 @@ use crate::utilities::utilities;
 /// # Examples
 /// ```
 /// use yarrow_runtime::utilities::mechanisms::laplace_mechanism;
-/// let n = laplace_mechanism(&0.1, &2.0)?;
+/// let n = laplace_mechanism(&0.1, &2.0);
+/// # n.unwrap();
 /// ```
 pub fn laplace_mechanism(epsilon: &f64, sensitivity: &f64) -> Result<f64> {
     let scale: f64 = sensitivity / epsilon;
@@ -62,7 +63,8 @@ pub fn laplace_mechanism(epsilon: &f64, sensitivity: &f64) -> Result<f64> {
 /// # Examples
 /// ```
 /// use yarrow_runtime::utilities::mechanisms::gaussian_mechanism;
-/// let n = gaussian_mechanism(&0.1, &0.0001, &2.0)?;
+/// let n = gaussian_mechanism(&0.1, &0.0001, &2.0);
+/// # n.unwrap();
 /// ```
 pub fn gaussian_mechanism(epsilon: &f64, delta: &f64, sensitivity: &f64) -> Result<f64> {
     let scale: f64 = sensitivity * (2. * (1.25 / delta).ln()).sqrt() / epsilon;
@@ -92,6 +94,7 @@ pub fn gaussian_mechanism(epsilon: &f64, delta: &f64, sensitivity: &f64) -> Resu
 /// ```
 /// use yarrow_runtime::utilities::mechanisms::simple_geometric_mechanism;
 /// let n = simple_geometric_mechanism(&0.1, &1., &0, &10, &true);
+/// # n.unwrap();
 /// ```
 pub fn simple_geometric_mechanism(epsilon: &f64, sensitivity: &f64, count_min: &i64, count_max: &i64, enforce_constant_time: &bool) -> Result<i64> {
     let scale: f64 = sensitivity / epsilon;
@@ -124,8 +127,8 @@ pub fn simple_geometric_mechanism(epsilon: &f64, sensitivity: &f64, count_min: &
 ///
 /// // create sample data
 /// let xs: ArrayD<f64> = arr1(&[1., 2., 3., 4., 5.]).into_dyn();
-/// let ans: f64 = exponential_mechanism(&1.0, &1.0, xs, &utility)?;
-/// println!("{}", ans);
+/// let ans = exponential_mechanism(&1.0, &1.0, xs, &utility);
+/// # ans.unwrap();
 /// ```
 pub fn exponential_mechanism<T>(
                          epsilon: &f64,

--- a/runtime-rust/src/utilities/noise.rs
+++ b/runtime-rust/src/utilities/noise.rs
@@ -31,18 +31,20 @@ impl ThreadRandGen for GeneratorOpenSSL {
 /// ```
 /// // returns a bit with Pr(bit = 1) = 0.7
 /// use yarrow_runtime::utilities::noise::sample_bit;
-/// let n:i64 = sample_bit(&0.7)?;
-/// assert!(n == 0 || n == 1);
+/// let n = sample_bit(&0.7);
+/// # n.unwrap();
 /// ```
 /// ```should_panic
 /// // fails because 1.3 not a valid probability
 /// use yarrow_runtime::utilities::noise::sample_bit;
-/// let n:i64 = sample_bit(&1.3)?;
+/// let n = sample_bit(&1.3);
+/// # n.unwrap();
 /// ```
 /// ```should_panic
 /// // fails because -0.3 is not a valid probability
 /// use yarrow_runtime::utilities::noise::sample_bit;
-/// let n:i64 = sample_bit(&-0.3)?;
+/// let n = sample_bit(&-0.3);
+/// # n.unwrap();
 /// ```
 pub fn sample_bit(prob: &f64) -> Result<i64> {
 
@@ -81,14 +83,15 @@ pub fn sample_bit(prob: &f64) -> Result<i64> {
 /// ```
 /// // returns a uniform draw from the set {0,1,2}
 /// use yarrow_runtime::utilities::noise::sample_uniform_int;
-/// let n:i64 = sample_uniform_int(&0, &2)?;
-/// assert!(n == 0 || n == 1 || n == 2);
+/// let n = sample_uniform_int(&0, &2);
+/// # n.unwrap();
 /// ```
 ///
 /// ```should_panic
 /// // fails because min > max
 /// use yarrow_runtime::utilities::noise::sample_uniform_int;
-/// let n:i64 = sample_uniform_int(&2, &0)?;
+/// let n = sample_uniform_int(&2, &0);
+/// # n.unwrap();
 /// ```
 pub fn sample_uniform_int(min: &i64, max: &i64) -> Result<i64> {
 
@@ -151,13 +154,14 @@ pub fn sample_uniform_int(min: &i64, max: &i64) -> Result<i64> {
 /// ```
 /// // valid draw from Unif[0,2)
 /// use yarrow_runtime::utilities::noise::sample_uniform;
-/// let unif: f64 = sample_uniform(&0.0, &2.0)?;
-/// assert!(unif >= 0.0 && unif < 2.0);
+/// let unif = sample_uniform(&0.0, &2.0);
+/// # unif.unwrap();
 /// ```
 /// ``` should_panic
 /// // fails because min > max
 /// use yarrow_runtime::utilities::noise::sample_uniform;
-/// let unif: f64 = sample_uniform(&2.0, &0.0)?;
+/// let unif = sample_uniform(&2.0, &0.0);
+/// # unif.unwrap();
 /// ```
 pub fn sample_uniform(min: &f64, max: &f64) -> Result<f64> {
     if min > max {return Err("min cannot be less than max".into());}
@@ -198,7 +202,8 @@ pub fn sample_uniform(min: &f64, max: &f64) -> Result<f64> {
 /// # Example
 /// ```
 /// use yarrow_runtime::utilities::noise::sample_uniform_mpfr;
-/// let unif: f64 = sample_uniform_mpfr(0.0, 1.0)?;
+/// let unif = sample_uniform_mpfr(0.0, 1.0);
+/// # unif.unwrap();
 /// ```
 pub fn sample_uniform_mpfr(min: f64, max: f64) -> Result<rug::Float> {
     // initialize 64-bit floats within mpfr/rug
@@ -218,7 +223,7 @@ pub fn sample_uniform_mpfr(min: f64, max: f64) -> Result<rug::Float> {
     return Ok(unif);
 }
 
-/// Generates a draw from Gaussian(shift, scale) using the MPFR library
+/// Generates a draw from a Gaussian distribution using the MPFR library.
 ///
 /// If [min, max] == [0, 1],then this is done in a way that respects exact rounding.
 /// Otherwise, the return will be the result of a composition of two operations that
@@ -227,9 +232,10 @@ pub fn sample_uniform_mpfr(min: f64, max: f64) -> Result<rug::Float> {
 /// We are working through what exactly exact rounding buys us from a privacy perspective --
 /// for more information, see the whitepapers/noise document in the CC_add_mpfr branch.
 ///
+///
 /// # Arguments
-/// * `shift` - Expectation of Gaussian distribution.
-/// * `scale` - Variance of Gaussian Distribution.
+/// * `shift` - The expectation of the Gaussian distribution.
+/// * `scale` - The scaling parameter (standard deviation) of the Gaussian distribution.
 ///
 /// # Return
 /// Draw from Gaussian(min, max)
@@ -237,12 +243,15 @@ pub fn sample_uniform_mpfr(min: f64, max: f64) -> Result<rug::Float> {
 /// # Example
 /// ```
 /// use yarrow_runtime::utilities::noise::sample_gaussian_mpfr;
-/// let gaussian: f64 = sample_gaussian_mpfr(0.0, 1.0)?;
+/// let gaussian = sample_gaussian_mpfr(0.0, 1.0);
+/// # gaussian.unwrap();
 /// ```
-pub fn sample_gaussian_mpfr(shift: f64, scale:f64) -> Result<rug::Float> {
+pub fn sample_gaussian_mpfr(shift: f64, scale: f64) -> Result<rug::Float> {
     // initialize 64-bit floats within mpfr/rug
+    // NOTE: We square the scale here because we ask for the standard deviation as the function input, but
+    //       the mpfr library wants the variance. We ask for std. dev. to be consistent with the rest of the library.
     let mpfr_shift = Float::with_val(53, shift);
-    let mpfr_scale = Float::with_val(53, scale);
+    let mpfr_scale = Float::with_val(53, Float::with_val(53, scale).square());
 
     // initialize randomness
     let mut rng = GeneratorOpenSSL {};
@@ -269,7 +278,8 @@ pub fn sample_gaussian_mpfr(shift: f64, scale:f64) -> Result<rug::Float> {
 /// # Example
 /// ```
 /// use yarrow_runtime::utilities::noise::sample_laplace;
-/// let n:f64 = sample_laplace(0.0, 2.0)?;
+/// let n = sample_laplace(0.0, 2.0);
+/// # n.unwrap();
 /// ```
 pub fn sample_laplace(shift: f64, scale: f64) -> Result<f64> {
     let probability: f64 = sample_uniform(&0., &1.)?;
@@ -281,7 +291,7 @@ pub fn sample_laplace(shift: f64, scale: f64) -> Result<f64> {
 /// # Arguments
 ///
 /// * `shift` - The expectation of the Gaussian distribution.
-/// * `scale` - The scaling parameter (variance) of the Gaussian distribution.
+/// * `scale` - The scaling parameter (standard deviation) of the Gaussian distribution.
 ///
 /// Return
 /// A draw from Gaussian(shift, scale).
@@ -289,7 +299,8 @@ pub fn sample_laplace(shift: f64, scale: f64) -> Result<f64> {
 /// # Example
 /// ```
 /// use yarrow_runtime::utilities::noise::sample_gaussian;
-/// let n:f64 = sample_gaussian(&0.0, &2.0)?;
+/// let n = sample_gaussian(&0.0, &2.0);
+/// # n.unwrap();
 /// ```
 pub fn sample_gaussian(shift: &f64, scale: &f64) -> Result<f64> {
     let probability: f64 = sample_uniform(&0., &1.)?;
@@ -305,8 +316,8 @@ pub fn sample_gaussian(shift: &f64, scale: &f64) -> Result<f64> {
 ///
 /// # Arguments
 ///
-/// * `shift` - The expectation of the Gaussian.
-/// * `scale` - The scaling parameter (variance) of the Gaussian distribution.
+/// * `shift` - The expectation of the untruncated Gaussian distribution.
+/// * `scale` - The scaling parameter (standard deviation) of the untruncated Gaussian distribution.
 /// * `min` - The minimum value you want to allow to be sampled.
 /// * `max` - The maximum value you want to allow to be sampled.
 ///
@@ -316,9 +327,8 @@ pub fn sample_gaussian(shift: &f64, scale: &f64) -> Result<f64> {
 /// # Example
 /// ```
 /// use yarrow_runtime::utilities::noise::sample_gaussian_truncated;
-/// let n:f64 = sample_gaussian_truncated(&1.0, &1.0, &0.0, &2.0)?;
-/// assert!(n >= 0.0);
-/// assert!(n <= 2.0);
+/// let n= sample_gaussian_truncated(&1.0, &1.0, &0.0, &2.0);
+/// # n.unwrap();
 /// ```
 pub fn sample_gaussian_truncated(min: &f64, max: &f64, shift: &f64, scale: &f64) -> Result<f64> {
     // TODO: why can't probability take a ref? perhaps need to drop the dependency
@@ -372,18 +382,19 @@ pub fn sample_floating_point_probability_exponent() -> Result<i16> {
 /// number of trials "max_trials".
 ///
 /// # Arguments
-/// * `prob` - parameter for the geometric distribution, the probability of success on any given trials
-/// * `max_trials` - the maximum number of trials allowed
-/// * `enforce_constant_time` - whether or not to enforce the algorithm to run in constant time; if true,
-///                             it will always run for "max_trials" trials
+/// * `prob` - Parameter for the geometric distribution, the probability of success on any given trials.
+/// * `max_trials` - The maximum number of trials allowed.
+/// * `enforce_constant_time` - Whether or not to enforce the algorithm to run in constant time; if true,
+///                             it will always run for "max_trials" trials.
 ///
 /// # Return
-/// result from censored geometric distribution
+/// A draw from the censored geometric distribution.
 ///
 /// # Example
 /// ```
 /// use yarrow_runtime::utilities::noise::sample_geometric_censored;
-/// let geom: i64 = sample_geometric_censored(&0.1, &20, &false)?;
+/// let geom = sample_geometric_censored(&0.1, &20, &false);
+/// # geom.unwrap();
 /// ```
 pub fn sample_geometric_censored(prob: &f64, max_trials: &i64, enforce_constant_time: &bool) -> Result<i64> {
 
@@ -439,7 +450,8 @@ pub fn sample_geometric_censored(prob: &f64, max_trials: &i64, enforce_constant_
 /// ```
 /// use ndarray::prelude::*;
 /// use yarrow_runtime::utilities::noise::sample_simple_geometric_mechanism;
-/// let geom_noise: i64 = sample_simple_geometric_mechanism(&1., &0, &100, &false)?;
+/// let geom_noise = sample_simple_geometric_mechanism(&1., &0, &100, &false);
+/// # geom_noise.unwrap();
 /// ```
 pub fn sample_simple_geometric_mechanism(scale: &f64, min: &i64, max: &i64, enforce_constant_time: &bool) -> Result<i64> {
 


### PR DESCRIPTION
I updated the tests I wrote so far to ensure that `cargo test` runs successfully for all tests.
This involved some actual fixes to mistakes in the tests, as well as updating the way we write them based on the `yarrow-internals` thread about using the following construction for tests 
```
/// let n = simple_geometric_mechanism(&0.1, &1., &0, &10, &true);
/// # n.unwrap();
```

These will hopefully be a better template for writing future tests than they were previously.