### PR TITLE
covariance, finite samples, proof port, indexing

### DIFF
--- a/bindings-python/tests/test_base.py
+++ b/bindings-python/tests/test_base.py
@@ -11,6 +11,7 @@ assert isfile(TEST_CSV_PATH), f'Error: file not found: {TEST_CSV_PATH}'
 
 test_csv_names = ["age", "sex", "educ", "race", "income", "married"]
 
+
 def test_multilayer_analysis(run=True):
 
     with whitenoise.Analysis() as analysis:
@@ -94,6 +95,18 @@ def test_dp_linear_stats(run=True):
         )
         analysis.release()
         print("number of records:", num_records.value)
+
+        vars = op.cast(dataset_pums[["age", "income"]], type="float")
+
+        covariance = op.dp_covariance(
+            data=vars,
+            privacy_usage={'epsilon': .5},
+            data_min=[0., 0.],
+            data_max=[150., 150000.],
+            data_n=num_records)
+
+        analysis.release()
+        print("covariance:\n", covariance.value)
 
         age = op.cast(age, type="FLOAT")
 

--- a/bindings-python/whitenoise/base.py
+++ b/bindings-python/whitenoise/base.py
@@ -64,6 +64,9 @@ class Dataset(object):
         if num_columns is None and column_names is None:
             raise ValueError("either num_columns or column_names must be set")
 
+        self.dataset_id = context.dataset_count
+        context.dataset_count += 1
+
         data_source = {}
         if path is not None:
             data_source['file_path'] = path
@@ -77,7 +80,8 @@ class Dataset(object):
                                    },
                                    options={
                                        "data_source": value_pb2.DataSource(**data_source),
-                                       "private": private
+                                       "private": private,
+                                       "dataset_id": value_pb2.I64Null(option=self.dataset_id)
                                    })
 
     def __getitem__(self, identifier):
@@ -201,6 +205,9 @@ class Component(object):
     def __abs__(self):
         return Component('Abs', arguments={'data': self})
 
+    def __getitem__(self, identifier):
+        return Component('Index', arguments={'columns': Component.of(identifier), 'data': self})
+
     def __hash__(self):
         return id(self)
 
@@ -286,6 +293,9 @@ class Analysis(object):
         self.component_count = 0
         for component in components:
             self.add_component(component)
+
+        # track the number of datasets in use
+        self.dataset_count = 0
 
         # nested analyses
         self._context_cache = None

--- a/prototypes/base.proto
+++ b/prototypes/base.proto
@@ -99,6 +99,7 @@ message ArrayNDProperties {
         NatureContinuous continuous = 10;
         NatureCategorical categorical = 11;
     }
+    I64Null dataset_id = 8;
 }
 message NatureContinuous {
     Array1dNull minimum = 1;

--- a/prototypes/components/Covariance.json
+++ b/prototypes/components/Covariance.json
@@ -28,13 +28,18 @@
   "id": "Covariance",
   "name": "covariance",
   "options": {
+    "finite_sample_correction": {
+      "type": "bool",
+      "default": "True",
+      "description": "Whether or not to use the finite sample correction (Bessel's correction)."
+    }
   },
   "return": {
     "nature": [
       "continuous"
     ],
     "type": "Array",
-    "description": "Covariance of data."
+    "description": "Flattened covariance or cross-covariance matrix."
   },
   "description": "Calculate sample covariance.\n\n If `data` argument is provided as a 2D array, calculate covariance matrix. Otherwise, `left` and `right` 1D arrays are used to calculate a single covariance."
 }

--- a/prototypes/components/DPCovariance.json
+++ b/prototypes/components/DPCovariance.json
@@ -31,6 +31,11 @@
     },
     "privacy_usage": {
       "type": "repeated PrivacyUsage"
+    },
+    "finite_sample_correction": {
+      "type": "bool",
+      "default": "True",
+      "description": "Whether or not to use the finite sample correction (Bessel's correction)."
     }
   },
   "return": {

--- a/prototypes/components/Materialize.json
+++ b/prototypes/components/Materialize.json
@@ -16,6 +16,11 @@
     "private": {
       "type": "bool",
       "default": "True"
+    },
+    "dataset_id": {
+      "type": "I64Null",
+      "default": "None",
+      "description": "when set, data with unknown number of records may still conform to data with the same dataset_id"
     }
   },
   "return": {

--- a/prototypes/components/Reshape.json
+++ b/prototypes/components/Reshape.json
@@ -1,0 +1,34 @@
+{
+  "arguments": {
+    "data": {
+      "default": "None",
+      "type": "Array",
+      "description": "Vector of data to stack into a matrix.\nA Hashmap of matrices will be emitted if multiple rows are provided."
+    }
+  },
+  "id": "Reshape",
+  "name": "reshape",
+  "options": {
+    "symmetric": {
+      "type": "bool",
+      "default": "False",
+      "description": "Set if data is elements from the upper triangle of a symmetric matrix."
+    },
+    "layout": {
+      "type": "string",
+      "description": "Consecutive elements of either the `row` or `column` reside next to each other."
+    },
+    "shape": {
+      "type": "repeated uint32",
+      "description": "The shape of the output matrix."
+    }
+  },
+  "return": {
+    "nature": [
+      "continuous"
+    ],
+    "type": "Array",
+    "description": "Reshape of data."
+  },
+  "description": "Reshape a row vector into a matrix"
+}

--- a/runtime-rust/src/base.rs
+++ b/runtime-rust/src/base.rs
@@ -101,7 +101,7 @@ pub fn execute_graph(analysis: &proto::Analysis,
                 .get(component.arguments.get(k).unwrap()).unwrap().clone()))
             .collect::<HashMap<String, Value>>();
 
-//        println!("expanding component {:?}", component);
+//        println!("expanding {:?}", component);
 //        println!("public arguments {:?}", public_arguments);
 //        println!("node properties {:?}", node_properties);
 

--- a/runtime-rust/src/components/cast.rs
+++ b/runtime-rust/src/components/cast.rs
@@ -14,20 +14,20 @@ impl Evaluable for proto::Cast {
         let output_type = get_argument(&arguments, "type")?.get_first_str()?;
 
         let data = get_argument(&arguments, "data")?.get_arraynd()?;
-        match &output_type {
+        match output_type.to_lowercase().as_str() {
             // if casting to bool, identify what value should map to true, then cast
-            x if x == &"BOOL".to_string() => {
+            "bool" => {
                 let true_label = get_argument(&arguments, "true_label")?.get_arraynd()?;
                 Ok(cast_bool(&data, &true_label)?.into())
             },
-            x if x == &"FLOAT".to_string() => Ok(Value::ArrayND(ArrayND::F64(cast_f64(&data)?))),
-            x if x == &"INT".to_string() => {
+            "float" | "real" => Ok(Value::ArrayND(ArrayND::F64(cast_f64(&data)?))),
+            "int" | "integer" => {
                 // TODO: handle different bounds on each column
                 let min = get_argument(&arguments, "min")?.get_first_i64()?;
                 let max = get_argument(&arguments, "max")?.get_first_i64()?;
                 Ok(cast_i64(&data, &min, &max)?.into())
             },
-            x if x == &"STRING".to_string() =>
+            "string" | "str" =>
                 Ok(cast_str(&data)?.into()),
             _ => Err("type is not recognized, must be BOOL, FLOAT, INT or STRING".into())
         }

--- a/runtime-rust/src/components/count.rs
+++ b/runtime-rust/src/components/count.rs
@@ -3,9 +3,8 @@ use whitenoise_validator::errors::*;
 use crate::base::NodeArguments;
 use whitenoise_validator::base::{Value, ArrayND, get_argument};
 use crate::components::Evaluable;
-use ndarray::{ArrayD, Array};
+use ndarray::{ArrayD, Array, Axis};
 use whitenoise_validator::proto;
-use crate::utilities::utilities::get_num_columns;
 
 
 impl Evaluable for proto::Count {
@@ -33,22 +32,9 @@ impl Evaluable for proto::Count {
 /// use whitenoise_runtime::components::count::count;
 /// let data = arr2(&[ [false, false, true], [true, true, true] ]).into_dyn();
 /// let n = count(&data).unwrap();
-/// assert!(n == arr2(&[ [2, 2, 2] ]).into_dyn());
+/// assert!(n.first().unwrap() == &2);
 /// ```
 pub fn count<T: Clone>(data: &ArrayD<T>) -> Result<ArrayD<i64>> {
 
-    // iterate over the generalized columns. Of course, all columns will share the same length
-    let counts = data.gencolumns().into_iter()
-        .map(|column| column.len() as i64).collect::<Vec<i64>>();
-
-    let array = match data.ndim() {
-        1 => Array::from_shape_vec(vec![], counts),
-        2 => Array::from_shape_vec(vec![1 as usize, get_num_columns(&data)? as usize], counts),
-        _ => return Err("invalid data shape for Count".into())
-    };
-
-    match array {
-        Ok(array) => Ok(array),
-        Err(_) => Err("unable to package Count result into an array".into())
-    }
+    Ok(Array::from_shape_vec(vec![], vec![data.len_of(Axis(0)) as i64])?)
 }

--- a/runtime-rust/src/components/covariance.rs
+++ b/runtime-rust/src/components/covariance.rs
@@ -1,29 +1,35 @@
 use whitenoise_validator::errors::*;
 
 use crate::base::NodeArguments;
-use whitenoise_validator::base::{Value, get_argument, Vector2DJagged};
+use whitenoise_validator::base::{Value, get_argument};
 use crate::components::Evaluable;
 use ndarray::{ArrayD, Array};
 
 use whitenoise_validator::proto;
 use crate::components::mean::mean;
 use ndarray::prelude::*;
+use std::iter::FromIterator;
 
 impl Evaluable for proto::Covariance {
     fn evaluate(&self, arguments: &NodeArguments) -> Result<Value> {
+        let delta_degrees_of_freedom = if self.finite_sample_correction {1} else {0} as usize;
         if arguments.contains_key("data") {
             let data = get_argument(&arguments, "data")?.get_arraynd()?.get_f64()?;
+            let covariances = matrix_covariance(&data, &delta_degrees_of_freedom)?.into_iter()
+                .flat_map(|x| x)
+                .collect::<Vec<f64>>();
 
-            return Ok(Value::Vector2DJagged(Vector2DJagged::F64(matrix_covariance(&data)?
-                .iter().map(|v| Some(v.clone())).collect())));
+            // flatten into a row vector, every column is a release
+            return Ok(arr1(&covariances).insert_axis(Axis(0)).into_dyn().into());
         }
         if arguments.contains_key("left") && arguments.contains_key("right") {
             let left = get_argument(&arguments, "left")?.get_arraynd()?.get_f64()?;
             let right = get_argument(&arguments, "right")?.get_arraynd()?.get_f64()?;
 
-            let cross_cov = matrix_cross_covariance(&left, &right)?;
+            let cross_covariances = matrix_cross_covariance(&left, &right, &delta_degrees_of_freedom)?;
 
-            return Ok(cross_cov.into());
+            // flatten into a row vector, every column is a release
+            return Ok(Array::from_iter(cross_covariances.iter()).insert_axis(Axis(0)).into_dyn().mapv(|v| v.clone()).into());
         }
         Err("insufficient data supplied to Covariance".into())
     }
@@ -33,6 +39,7 @@ impl Evaluable for proto::Covariance {
 ///
 /// # Arguments
 /// * `data` - Data for which you want covariance matrix.
+/// * `delta_degrees_of_freedom` - 0 for population, 1 for finite sample correction
 ///
 /// # Return
 /// Upper triangular of covariance matrix of your data.
@@ -48,12 +55,12 @@ impl Evaluable for proto::Covariance {
 /// // [-7.5 -4.5  4.5]
 ///
 /// let data = arr2(&[ [0., 2., 9.], [5., 5., 6.] ]).into_dyn();
-/// let cov_mat = matrix_covariance(&data).unwrap();
+/// let cov_mat = matrix_covariance(&data, &1).unwrap();
 /// assert!(cov_mat == vec![ vec![12.5, 7.5, -7.5], vec![4.5, -4.5], vec![4.5] ]);
 /// ```
-pub fn matrix_covariance(data: &ArrayD<f64>) -> Result<Vec<Vec<f64>>> {
+pub fn matrix_covariance(data: &ArrayD<f64>, delta_degrees_of_freedom: &usize) -> Result<Vec<Vec<f64>>> {
 
-    let means: Vec<f64> = mean(&data)?.iter().map(|v| v.clone()).collect();
+    let means: Vec<f64> = mean(&data)?.iter().cloned().collect();
 
     let mut covariances: Vec<Vec<f64>> = Vec::new();
     data.gencolumns().into_iter().enumerate()
@@ -62,7 +69,10 @@ pub fn matrix_covariance(data: &ArrayD<f64>) -> Result<Vec<Vec<f64>>> {
             data.gencolumns().into_iter().enumerate()
                 .filter(|(right_i, _right_col)| &left_i <= right_i)
                 .for_each(|(right_i, right_col)|
-                    col_covariances.push(covariance(&left_col, &right_col, &means[left_i].clone(), &means[right_i].clone())));
+                    col_covariances.push(covariance(
+                        &left_col, &right_col,
+                        &means[left_i].clone(), &means[right_i].clone(),
+                        delta_degrees_of_freedom)));
             covariances.push(col_covariances);
         });
     Ok(covariances)
@@ -76,6 +86,7 @@ pub fn matrix_covariance(data: &ArrayD<f64>) -> Result<Vec<Vec<f64>>> {
 /// # Arguments
 /// * `left` - One of the two matrices for which you want the cross-covariance matrix.
 /// * `right` - One of the two matrices for which you want the cross-covariance matrix.
+/// * `delta_degrees_of_freedom` - 0 for population, 1 for finite sample correction
 ///
 /// # Return
 /// Full cross-covariance matrix.
@@ -88,25 +99,31 @@ pub fn matrix_covariance(data: &ArrayD<f64>) -> Result<Vec<Vec<f64>>> {
 /// let left = arr2(&[ [1., 3., 5.,], [2., 4., 6.] ]).into_dyn();
 /// let right = arr2(&[ [2., 4., 6.], [1., 3., 5.] ]).into_dyn();
 ///
-/// let cross_covar = matrix_cross_covariance(&left, &right).unwrap();
-/// let left_covar = matrix_cross_covariance(&left, &left).unwrap();
+/// let cross_covar = matrix_cross_covariance(&left, &right, &(1 as usize)).unwrap();
+/// let left_covar = matrix_cross_covariance(&left, &left, &(1 as usize)).unwrap();
 ///
 /// // cross-covariance of left and right matrices
 /// assert!(cross_covar == arr2(&[ [-0.5, -0.5, -0.5], [-0.5, -0.5, -0.5], [-0.5, -0.5, -0.5] ]).into_dyn());
 ///
 /// // cross-covariance of left with itself is equivalent to the standard covariance matrix
 /// assert!(left_covar == arr2(&[ [0.5, 0.5, 0.5], [0.5, 0.5, 0.5], [0.5, 0.5, 0.5] ]).into_dyn());
-pub fn matrix_cross_covariance(left: &ArrayD<f64>, right: &ArrayD<f64>) -> Result<ArrayD<f64>> {
+pub fn matrix_cross_covariance(
+    left: &ArrayD<f64>, right: &ArrayD<f64>,
+    delta_degrees_of_freedom: &usize
+) -> Result<ArrayD<f64>> {
 
-    let left_means: Vec<f64> = mean(&left)?.iter().map(|v| v.clone()).collect();
-    let right_means: Vec<f64> = mean(&right)?.iter().map(|v| v.clone()).collect();
+    let left_means: Vec<f64> = mean(&left)?.iter().cloned().collect();
+    let right_means: Vec<f64> = mean(&right)?.iter().cloned().collect();
 
     let covariances = left.gencolumns().into_iter()
         .zip(left_means.iter())
         .flat_map(|(column_left, mean_left)|
             right.gencolumns().into_iter()
                 .zip(right_means.iter())
-                .map(|(column_right, mean_right)| covariance(&column_left, &column_right, &mean_left, &mean_right))
+                .map(|(column_right, mean_right)| covariance(
+                    &column_left, &column_right,
+                    &mean_left, &mean_right,
+                &delta_degrees_of_freedom))
                 .collect::<Vec<f64>>())
         .collect::<Vec<f64>>();
 
@@ -123,6 +140,7 @@ pub fn matrix_cross_covariance(left: &ArrayD<f64>, right: &ArrayD<f64>) -> Resul
 /// * `right` - One of the two arrays for which you want the covariance.
 /// * `mean_left` - Arithmetic mean of the left array.
 /// * `mean_right` - Arithmetic mean of the right array.
+/// * `delta_degrees_of_freedom` - 0 for population, 1 for finite sample correction
 ///
 /// # Return
 /// Covariance of the two arrays.
@@ -136,12 +154,12 @@ pub fn matrix_cross_covariance(left: &ArrayD<f64>, right: &ArrayD<f64>) -> Resul
 /// let right = arr1(&[4.,5.,6.]);
 /// let mean_left = 2.;
 /// let mean_right = 5.;
-/// let cov = covariance(&left.view(), &right.view(), &mean_left, &mean_right);
+/// let cov = covariance(&left.view(), &right.view(), &mean_left, &mean_right, &1);
 /// assert!(cov == 1.);
 /// ```
-pub fn covariance(left: &ArrayView1<f64>, right: &ArrayView1<f64>, mean_left: &f64, mean_right: &f64) -> f64 {
+pub fn covariance(left: &ArrayView1<f64>, right: &ArrayView1<f64>, mean_left: &f64, mean_right: &f64, delta_degrees_of_freedom: &usize) -> f64 {
     left.iter()
         .zip(right)
         .fold(0., |sum, (val_left, val_right)|
-            sum + ((val_left - mean_left) * (val_right - mean_right))) / ( (left.len() - 1) as f64)
+            sum + ((val_left - mean_left) * (val_right - mean_right))) / ( (left.len() - delta_degrees_of_freedom.clone()) as f64)
 }

--- a/runtime-rust/src/components/filter.rs
+++ b/runtime-rust/src/components/filter.rs
@@ -8,7 +8,7 @@ use ndarray::{ArrayD, Axis, Array1};
 
 use whitenoise_validator::proto;
 
-use crate::utilities::array::select;
+use crate::utilities::array::slow_select;
 
 
 impl Evaluable for proto::Filter {
@@ -43,7 +43,7 @@ impl Evaluable for proto::Filter {
 /// let filtered = filter(&data, &mask).unwrap();
 /// assert!(filtered == arr2(&[ [1, 2, 3], [7, 8, 9] ]).into_dyn());
 /// ```
-pub fn filter<T: Clone>(data: &ArrayD<T>, mask: &ArrayD<bool>) -> Result<ArrayD<T>> {
+pub fn filter<T: Clone + Default>(data: &ArrayD<T>, mask: &ArrayD<bool>) -> Result<ArrayD<T>> {
 
     let columnar_mask: Array1<bool> = mask.clone().into_dimensionality::<Ix1>().unwrap();
 
@@ -51,5 +51,5 @@ pub fn filter<T: Clone>(data: &ArrayD<T>, mask: &ArrayD<bool>) -> Result<ArrayD<
         .filter(|(_index, &v)| v)
         .map(|(index, _)| index)
         .collect();
-    Ok(select(&data, Axis(0), &mask_indices))
+    Ok(slow_select(&data, Axis(0), &mask_indices))
 }

--- a/runtime-rust/src/components/index.rs
+++ b/runtime-rust/src/components/index.rs
@@ -1,39 +1,162 @@
 use whitenoise_validator::errors::*;
 
 use crate::base::NodeArguments;
-use whitenoise_validator::base::{Value, ArrayND, get_argument, Hashmap};
+use whitenoise_validator::base::{Value, ArrayND, get_argument, Hashmap, DataType};
 use crate::components::Evaluable;
 use whitenoise_validator::proto;
+use crate::utilities::array::{slow_stack, slow_select};
+use ndarray::prelude::*;
+use std::collections::HashMap;
 
+use whitenoise_validator::components::index::{to_name_vec, mask_columns};
 
 
 impl Evaluable for proto::Index {
     fn evaluate(&self, arguments: &NodeArguments) -> Result<Value> {
         let data = get_argument(&arguments, "data")?;
-        let columns = get_argument(&arguments, "columns")?;
+        let columns = get_argument(&arguments, "columns")?.get_arraynd()?;
 
         match data {
-            Value::Hashmap(dataframe) => match columns {
-                Value::ArrayND(array) => match (dataframe, array) {
-                    (Hashmap::Str(dataframe), ArrayND::Str(column_names)) => match column_names.ndim() {
-                        0 => Ok(dataframe.get(column_names.first().unwrap()).unwrap().to_owned()),
-//                1 => match column_names.into_dimensionality::<Ix1>() {
-//                    Ok(column_names) =>
-//                        Value::Str(stack(Axis(0), column_names.to_vec().iter()
-//                            .map(|column_name| match dataframe.get(column_names.first().unwrap()).unwrap() {
-//                                Value::Str(array) => array,
-//                                _ => panic!("selected data frame columns are not of a homogenous type".to_string())
-//                            }).collect()).unwrap())
-//                            .collect::<Vec<ArrayD<str>>>(),
-//                    _ => Err("column names must be at most 1-dimensional".to_owned()),
-//                },
-                        _ => Err("column names must be at most 1-dimensional".into())
+            // if value is a hashmap, we'll be stacking arrays column-wise
+            Value::Hashmap(dataframe) => match dataframe {
+                Hashmap::Str(dataframe) => match columns {
+                    ArrayND::Str(columns) => column_stack(
+                        dataframe, &to_name_vec(columns)?),
+                    ArrayND::I64(columns) => {
+                        let column_names = dataframe.keys().cloned().collect::<Vec<String>>();
+                        let columns = to_name_vec(columns)?.iter()
+                            .map(|index| column_names.get(*index as usize).cloned()
+                                .ok_or::<Error>("column index out of bounds".into())).collect::<Result<Vec<String>>>()?;
+                        column_stack(dataframe, &columns)
                     },
-                    _ => Err("column names must be strings".into())
+                    ArrayND::Bool(columns) => column_stack(dataframe, &mask_columns(
+                        &dataframe.keys().cloned().collect::<Vec<String>>(),
+                        &to_name_vec(columns)?)?),
+                    _ => Err("the data type of the column headers is not supported".into())
                 },
-                _ => Err("column names must an array".into())
+                Hashmap::I64(dataframe) => {
+                    match columns {
+                        ArrayND::I64(columns) => column_stack(dataframe, &to_name_vec(columns)?),
+                        ArrayND::Bool(columns) => column_stack(dataframe, &mask_columns(
+                            &dataframe.keys().cloned().collect::<Vec<i64>>(),
+                            &to_name_vec(columns)?)?),
+                        _ => Err("the data type of the column headers is not supported".into())
+                    }
+                },
+                Hashmap::Bool(dataframe) => {
+                    let columns = columns.get_bool()?;
+                    column_stack(dataframe, &to_name_vec(columns)?)
+                }
             },
-            _ => Err("indexing is only implemented for hashmaps".into())
+
+            // if the value is an array, we'll be selecting columns
+            Value::ArrayND(array) => {
+                let indices = match columns {
+                    ArrayND::Bool(mask) => to_name_vec(mask)?.into_iter().enumerate()
+                        .filter(|(_, mask)| *mask)
+                        .map(|(idx, _)| idx)
+                        .collect::<Vec<usize>>(),
+                    ArrayND::I64(indices) => to_name_vec(indices)?.into_iter()
+                        .map(|v| v as usize).collect(),
+                    _ => return Err("the data type of the indices are not supported".into())
+                };
+                Ok(match array {
+                    ArrayND::I64(data) => data.select(Axis(1), &indices).into(),
+                    ArrayND::F64(data) => data.select(Axis(1), &indices).into(),
+                    ArrayND::Bool(data) => data.select(Axis(1), &indices).into(),
+                    ArrayND::Str(data) => slow_select(data, Axis(1), &indices).into(),
+                })
+            }
+            Value::Vector2DJagged(_) => Err("indexing is not supported for jagged arrays".into())
         }
     }
+}
+
+fn column_stack<T: Clone + Eq + std::hash::Hash>(
+    dataframe: &HashMap<T, Value>, column_names: &Vec<T>
+) -> Result<Value> {
+    if column_names.len() == 1 {
+        return dataframe.get(column_names.first().unwrap()).cloned()
+            .ok_or::<Error>("the provided column name does not exist".into())
+    }
+
+    let values = column_names.iter()
+        .map(|column_name| dataframe.get(column_name))
+        .collect::<Option<Vec<&Value>>>()
+        .ok_or::<Error>("one of the provided column names does not exist".into())?;
+
+    let data_type = match values.first() {
+        Some(value) => match value.get_arraynd()? {
+            ArrayND::F64(_) => DataType::F64,
+            ArrayND::I64(_) => DataType::I64,
+            ArrayND::Bool(_) => DataType::Bool,
+            ArrayND::Str(_) => DataType::Str,
+        },
+        None => return Err("at least one column must be supplied to Index".into())
+    };
+
+    match data_type {
+        DataType::F64 => {
+            let chunks = column_names.iter()
+                .map(|column_name| dataframe.get(column_name)
+                    .ok_or("one of the provided column names does not exist".into())
+                    .and_then(|array| to_2d(array.get_arraynd()?.get_f64()?.clone())))
+                .collect::<Result<Vec<_>>>()?;
+
+            Ok(ndarray::stack(Axis(1), &chunks.iter()
+                .map(|chunk| chunk.view()).collect::<Vec<ArrayViewD<_>>>())?.into())
+        }
+        DataType::I64 => {
+            let chunks = column_names.iter()
+                .map(|column_name| dataframe.get(column_name)
+                    .ok_or("one of the provided column names does not exist".into())
+                    .and_then(|array| to_2d(array.get_arraynd()?.get_i64()?.clone())))
+                .collect::<Result<Vec<_>>>()?;
+
+            Ok(ndarray::stack(Axis(1), &chunks.iter()
+                .map(|chunk| chunk.view()).collect::<Vec<ArrayViewD<_>>>())?.into())
+        }
+        DataType::Bool => {
+            let chunks = column_names.iter()
+                .map(|column_name| dataframe.get(column_name)
+                    .ok_or("one of the provided column names does not exist".into())
+                    .and_then(|array| to_2d(array.get_arraynd()?.get_bool()?.clone())))
+                .collect::<Result<Vec<_>>>()?;
+
+            Ok(ndarray::stack(Axis(1), &chunks.iter()
+                .map(|chunk| chunk.view()).collect::<Vec<ArrayViewD<_>>>())?.into())
+        }
+        DataType::Str => {
+            let chunks = column_names.iter()
+                .map(|column_name| dataframe.get(column_name)
+                    .ok_or("one of the provided column names does not exist".into())
+                    .and_then(|array| to_2d(array.get_arraynd()?.get_str()?.clone())))
+                .collect::<Result<Vec<ArrayD<String>>>>()?;
+
+            Ok(slow_stack(Axis(1), &chunks.iter()
+                .map(|chunk| chunk.view()).collect::<Vec<ArrayViewD<String>>>())?.into())
+        }
+    }
+}
+
+fn to_nd<T>(mut array: ArrayD<T>, ndim: &usize) -> Result<ArrayD<T>> {
+    match (*ndim as i32) - (array.ndim() as i32) {
+        0 => {},
+        // must remove i axes
+        i if i < 0 => {
+            (0..-(i as i32)).map(|_| match array.shape().last().ok_or::<Error>("ndim may not be negative".into())? {
+                1 => Ok(array.index_axis_inplace(Axis(array.ndim().clone()), 0)),
+                _ => Err("cannot remove non-singleton trailing axis".into())
+            }).collect::<Result<_>>()?
+        },
+        // must add i axes
+        i if i > 0 => (0..i).for_each(|idx| array.insert_axis_inplace(Axis((idx + 1) as usize))),
+        _ => return Err("invalid dimensionality".into())
+    };
+
+    Ok(array)
+}
+
+fn to_2d<T>(array: ArrayD<T>) -> Result<ArrayD<T>> {
+    to_nd(array, &(2 as usize))
 }

--- a/runtime-rust/src/components/mod.rs
+++ b/runtime-rust/src/components/mod.rs
@@ -29,6 +29,7 @@ pub mod materialize;
 pub mod mean;
 pub mod minimum;
 pub mod quantile;
+pub mod reshape;
 pub mod mechanisms;
 pub mod resize;
 //pub mod row_max;
@@ -75,7 +76,7 @@ impl Evaluable for proto::component::Variant {
         evaluate!(
             // INSERT COMPONENT LIST
             Bin, Cast, Clamp, Count, Covariance, Filter, Impute, Index, KthRawSampleMoment, Maximum,
-            Materialize, Mean, Minimum, Quantile, LaplaceMechanism, GaussianMechanism,
+            Materialize, Mean, Minimum, Quantile, Reshape, LaplaceMechanism, GaussianMechanism,
             SimpleGeometricMechanism, Resize, Sum, Variance,
 
             Add, Subtract, Divide, Multiply, Power, Log, Modulo, LogicalAnd, LogicalOr, Negate,

--- a/runtime-rust/src/components/reshape.rs
+++ b/runtime-rust/src/components/reshape.rs
@@ -1,0 +1,156 @@
+use whitenoise_validator::errors::*;
+
+use crate::base::NodeArguments;
+use whitenoise_validator::base::{Value, ArrayND, get_argument};
+use crate::components::Evaluable;
+use ndarray::{ArrayD, Array};
+use whitenoise_validator::proto;
+use std::collections::HashMap;
+
+
+impl Evaluable for proto::Reshape {
+    fn evaluate(&self, arguments: &NodeArguments) -> Result<Value> {
+        let layout = match self.layout.to_lowercase().as_str() {
+            "row" => Layout::Row,
+            "column" => Layout::Column,
+            _ => return Err("layout: unrecognized format. Must be either row or column".into())
+        };
+
+        match get_argument(&arguments, "data")?.get_arraynd()? {
+            ArrayND::Bool(data) => {
+                let mut reshaped = reshape(&data, &self.symmetric, &layout, &self.shape)?;
+                match reshaped.len().clone() {
+                    0 => Err("at least one record is required to reshape".into()),
+                    1 => Ok(reshaped.remove(0).into()),
+                    _ => Ok(reshaped.into_iter().enumerate()
+                        .map(|(idx, data)| (idx as i64, data.into()))
+                        .collect::<HashMap<i64, Value>>().into())
+                }
+            }
+            ArrayND::I64(data) => {
+                let mut reshaped = reshape(&data, &self.symmetric, &layout, &self.shape)?;
+                match reshaped.len().clone() {
+                    0 => Err("at least one record is required to reshape".into()),
+                    1 => Ok(reshaped.remove(0).into()),
+                    _ => Ok(reshaped.into_iter().enumerate()
+                        .map(|(idx, data)| (idx as i64, data.into()))
+                        .collect::<HashMap<i64, Value>>().into())
+                }
+            }
+            ArrayND::F64(data) => {
+                let mut reshaped = reshape(&data, &self.symmetric, &layout, &self.shape)?;
+                match reshaped.len().clone() {
+                    0 => Err("at least one record is required to reshape".into()),
+                    1 => Ok(reshaped.remove(0).into()),
+                    _ => Ok(reshaped.into_iter().enumerate()
+                        .map(|(idx, data)| (idx as i64, data.into()))
+                        .collect::<HashMap<i64, Value>>().into())
+                }
+            }
+            ArrayND::Str(data) => {
+                let mut reshaped = reshape(&data, &self.symmetric, &layout, &self.shape)?;
+                match reshaped.len().clone() {
+                    0 => Err("at least one record is required to reshape".into()),
+                    1 => Ok(reshaped.remove(0).into()),
+                    _ => Ok(reshaped.into_iter().enumerate()
+                        .map(|(idx, data)| (idx as i64, data.into()))
+                        .collect::<HashMap<i64, Value>>().into())
+                }
+            }
+        }
+    }
+}
+
+#[derive(PartialEq)]
+pub enum Layout {
+    Row,
+    Column,
+}
+
+/// Gets number of rows of data.
+///
+/// # Arguments
+/// * `data` - Data for which you want a count.
+/// * `symmetric` - indicates if elements of data come from an upper triangular matrix, not a dense matrix
+/// * `layout` - indicates data resides in row major or column major order
+/// * `shape` - shape of output matrix
+///
+/// # Return
+/// Reshaped matrices, one matrix per row.
+///
+/// # Example
+/// ```
+/// use ndarray::{ArrayD, arr1, arr2};
+/// use whitenoise_runtime::components::reshape::{reshape, Layout};
+/// let data = arr2(&[ [false, false, true] ]).into_dyn();
+/// let n = reshape(&data, &true, &Layout::Row, &vec![2, 2]).unwrap();
+/// assert!(n[0] == arr2(&[ [false, false], [false, true] ]).into_dyn());
+/// ```
+pub fn reshape<T: Clone + std::fmt::Debug>(data: &ArrayD<T>, symmetric: &bool, layout: &Layout, shape: &Vec<u32>) -> Result<Vec<ArrayD<T>>> {
+    data.genrows().into_iter()
+        .map(|row| {
+            if *symmetric {
+                let row = row.to_vec();
+                let num_rows = match shape.len() {
+                    1 => shape[0],
+                    2 => {
+                        if shape[0] != shape[1] {
+                            return Err("the width and height must match to form a triangular matrix".into());
+                        }
+                        shape[0]
+                    }
+                    _ => return Err("shape must be 0 or 1-dimensional to form a triangular matrix".into())
+                };
+
+                if row.len() != (num_rows * (num_rows + 1) / 2) as usize {
+                    return Err("invalid number of elements in row for reshaping into symmetric matrix".into());
+                }
+
+                let full = match layout {
+                    Layout::Row =>
+                        (0..num_rows).map(|i|
+                            (0..num_rows).map(|j| if i <= j {
+                                // upper triangular (full matrix index, less the arithmetic progression)
+                                row[(i * num_rows + j - (i + 1) * i / 2) as usize].clone()
+                            } else {
+                                // lower triangular (symmetric with upper triangle)
+                                row[(j * num_rows + i - (j + 1) * j / 2) as usize].clone()
+                            }).collect()).flat_map(|x: Vec<T>| x).collect::<Vec<T>>(),
+                    Layout::Column => return Err("not implemented".into())
+                };
+
+                Ok(Array::from_shape_vec((num_rows as usize, num_rows as usize), full)?.into_dyn())
+            } else {
+                if &Layout::Column == layout {
+                    return Err("reshaping for dense columnar memory layouts is not supported".into());
+                }
+                let shape = shape.iter().map(|v| v.clone() as usize).collect::<Vec<usize>>();
+                match Array::from_shape_vec(shape, row.to_vec()) {
+                    Ok(arr) => Ok(arr),
+                    Err(_) => Err("reshape has incorrect size".into())
+                }
+            }
+        }).collect::<Result<Vec<ArrayD<T>>>>()
+}
+
+#[cfg(test)]
+mod reshape_tests {
+    use ndarray::{arr2};
+    use crate::components::reshape::{reshape, Layout};
+
+    #[test]
+    fn test_reshape_symmetric_2x2() {
+        let data = arr2(&[[false, false, true]]).into_dyn();
+        let n = reshape(&data, &true, &Layout::Row, &vec![2, 2]).unwrap();
+        assert!(n[0] == arr2(&[[false, false], [false, true]]).into_dyn());
+    }
+
+    #[test]
+    fn test_reshape_symmetric_4x4() {
+        let data = arr2(&[[0, 1, 2, 3, 4, 5, 6, 7, 8, 9]]).into_dyn();
+        let n = reshape(&data, &true, &Layout::Row, &vec![4, 4]).unwrap();
+        assert!(n[0] == arr2(&[[0, 1, 2, 3], [1, 4, 5, 6], [2, 5, 7, 8], [3, 6, 8, 9]]).into_dyn());
+    }
+
+
+}

--- a/runtime-rust/src/components/resize.rs
+++ b/runtime-rust/src/components/resize.rs
@@ -10,7 +10,7 @@ use crate::components::Evaluable;
 use crate::utilities::noise;
 use crate::components::impute::{impute_float_gaussian, impute_float_uniform, impute_categorical};
 use crate::utilities::utilities::get_num_columns;
-use crate::utilities::array::{select, stack};
+use crate::utilities::array::{slow_select, slow_stack};
 
 impl Evaluable for proto::Resize {
     fn evaluate(&self, arguments: &NodeArguments) -> Result<Value> {
@@ -113,14 +113,14 @@ pub fn resize_float(data: &ArrayD<f64>, n: &i64, distribution: &String,
             }?;
 
             // combine real and synthetic data
-            match stack(Axis(0), &[data.view(), synthetic.view()]) {
+            match ndarray::stack(Axis(0), &[data.view(), synthetic.view()]) {
                 Ok(value) => value,
                 Err(_) => return Err("failed to stack real and synthetic data".into())
             }
         },
         // if estimated n is smaller than real n, return a subset of the real data
         real_n if real_n > n =>
-            select(&data, Axis(0), &create_sampling_indices(&n, &real_n)?),
+            slow_select(&data, Axis(0), &create_sampling_indices(&n, &real_n)?),
 //            data.select(Axis(0), &create_sampling_indices(&n, &real_n)?).to_owned(),
         _ => return Err("invalid configuration for n when resizing".into())
     })
@@ -137,9 +137,12 @@ pub fn resize_float(data: &ArrayD<f64>, n: &i64, distribution: &String,
 ///
 /// # Return
 /// A resized version of data consistent with the provided `n`
-pub fn resize_categorical<T>(data: &ArrayD<T>, n: &i64,
-                             categories: &Vec<Option<Vec<T>>>, weights: &Vec<Option<Vec<f64>>>, null_value: &Vec<Option<Vec<T>>>,)
-                             -> Result<ArrayD<T>> where T: Clone, T: PartialEq, T: Default {
+pub fn resize_categorical<T>(
+    data: &ArrayD<T>, n: &i64,
+    categories: &Vec<Option<Vec<T>>>,
+    weights: &Vec<Option<Vec<f64>>>,
+    null_value: &Vec<Option<Vec<T>>>
+) -> Result<ArrayD<T>> where T: Clone, T: PartialEq, T: Default {
     // get number of observations in actual data
     let real_n: i64 = data.len_of(Axis(0)) as i64;
 
@@ -167,14 +170,14 @@ pub fn resize_categorical<T>(data: &ArrayD<T>, n: &i64,
                 &synthetic, &categories, &weights, &null_value)?;
 
             // combine real and synthetic data
-            match stack(Axis(0), &[data.view(), synthetic.view()]) {
+            match slow_stack(Axis(0), &[data.view(), synthetic.view()]) {
                 Ok(value) => value,
                 Err(_) => return Err("failed to stack real and synthetic data".into())
             }
         },
         // if estimated n is smaller than real n, return a subset of the real data
         real_n if real_n > n =>
-            select(data, Axis(0), &create_sampling_indices(&n, &real_n)?).to_owned(),
+            slow_select(data, Axis(0), &create_sampling_indices(&n, &real_n)?).to_owned(),
         _ => return Err("invalid configuration for n when resizing".into())
     })
 }

--- a/runtime-rust/src/utilities/array.rs
+++ b/runtime-rust/src/utilities/array.rs
@@ -2,19 +2,20 @@ use whitenoise_validator::errors::*;
 
 
 // TODO: open an issue on the rust ndarray package
-//  Requiring the Copy trait on stack makes this (necessary) part of ndarray unusable
+//  Requiring the Copy trait on stack makes strings un-stackable/un-selectable
 //  Pulled from the ndarray library, and tweaked to remove the Copy trait requirement
 
 use ndarray::{RemoveAxis, Axis, Ix, Array, ArrayView};
 
 use itertools::zip;
 
-pub fn stack<A, D>(
+pub fn slow_stack<A, D>(
     axis: Axis,
     arrays: &[ArrayView<A, D>],
 ) -> Result<Array<A, D>>
     where
         A: Clone,
+        A: Default,
         D: RemoveAxis,
 {
     if arrays.is_empty() {
@@ -35,13 +36,9 @@ pub fn stack<A, D>(
     let stacked_dim = arrays.iter().fold(0, |acc, a| acc + a.len_of(axis));
     res_dim[axis.index()] = stacked_dim;
 
-    // we can safely use uninitialized values here because they are Copy
-    // and we will only ever write to them
     let size = res_dim.size();
-    let mut v = Vec::with_capacity(size);
-    unsafe {
-        v.set_len(size);
-    }
+    let v = (0..size).map(|_| A::default()).collect();
+
     let mut res = match Array::from_shape_vec(res_dim, v) {
         Ok(v) => v, Err(_) => return Err("shape error when stacking, could not create array from shape vec".into())
     };
@@ -58,8 +55,9 @@ pub fn stack<A, D>(
     Ok(res)
 }
 
-pub fn select<A, D>(data: &Array<A, D>, axis: Axis, indices: &[Ix]) -> Array<A, D>
+pub fn slow_select<A, D>(data: &Array<A, D>, axis: Axis, indices: &[Ix]) -> Array<A, D>
     where
+        A: Default,
         A: Clone,
         D: RemoveAxis,
 {
@@ -70,8 +68,8 @@ pub fn select<A, D>(data: &Array<A, D>, axis: Axis, indices: &[Ix]) -> Array<A, 
     if subs.is_empty() {
         let mut dim = data.raw_dim();
         dim[axis.index()] = 0;
-        unsafe { Array::from_shape_vec_unchecked(dim, vec![]) }
+        Array::from_shape_vec(dim, vec![]).unwrap()
     } else {
-        stack(axis, &subs).unwrap()
+        slow_stack(axis, &subs).unwrap()
     }
 }

--- a/runtime-rust/src/utilities/mechanisms.rs
+++ b/runtime-rust/src/utilities/mechanisms.rs
@@ -30,13 +30,12 @@ use crate::utilities::utilities;
 /// ```
 /// use whitenoise_runtime::utilities::mechanisms::laplace_mechanism;
 /// let n = laplace_mechanism(&0.1, &2.0);
-/// # n.unwrap();
 /// ```
-pub fn laplace_mechanism(epsilon: &f64, sensitivity: &f64) -> Result<f64> {
+pub fn laplace_mechanism(epsilon: &f64, sensitivity: &f64) -> f64 {
     let scale: f64 = sensitivity / epsilon;
-    let noise: f64 = noise::sample_laplace(0., scale)?;
+    let noise: f64 = noise::sample_laplace(0., scale);
 
-    Ok(noise)
+    noise
 }
 
 /// Returns noise drawn according to the Gaussian mechanism.
@@ -64,12 +63,11 @@ pub fn laplace_mechanism(epsilon: &f64, sensitivity: &f64) -> Result<f64> {
 /// ```
 /// use whitenoise_runtime::utilities::mechanisms::gaussian_mechanism;
 /// let n = gaussian_mechanism(&0.1, &0.0001, &2.0);
-/// # n.unwrap();
 /// ```
-pub fn gaussian_mechanism(epsilon: &f64, delta: &f64, sensitivity: &f64) -> Result<f64> {
+pub fn gaussian_mechanism(epsilon: &f64, delta: &f64, sensitivity: &f64) -> f64 {
     let scale: f64 = sensitivity * (2. * (1.25 / delta).ln()).sqrt() / epsilon;
-    let noise: f64 = noise::sample_gaussian(&0., &scale)?;
-    Ok(noise)
+    let noise: f64 = noise::sample_gaussian(&0., &scale);
+    noise
 }
 
 /// Returns noise drawn according to the Geometric mechanism.
@@ -94,12 +92,11 @@ pub fn gaussian_mechanism(epsilon: &f64, delta: &f64, sensitivity: &f64) -> Resu
 /// ```
 /// use whitenoise_runtime::utilities::mechanisms::simple_geometric_mechanism;
 /// let n = simple_geometric_mechanism(&0.1, &1., &0, &10, &true);
-/// # n.unwrap();
 /// ```
-pub fn simple_geometric_mechanism(epsilon: &f64, sensitivity: &f64, count_min: &i64, count_max: &i64, enforce_constant_time: &bool) -> Result<i64> {
+pub fn simple_geometric_mechanism(epsilon: &f64, sensitivity: &f64, count_min: &i64, count_max: &i64, enforce_constant_time: &bool) -> i64 {
     let scale: f64 = sensitivity / epsilon;
-    let noise: i64 = noise::sample_simple_geometric_mechanism(&scale, &count_min, &count_max, &enforce_constant_time)?;
-    Ok(noise)
+    let noise: i64 = noise::sample_simple_geometric_mechanism(&scale, &count_min, &count_max, &enforce_constant_time);
+    noise
 }
 
 /// Returns data element according to the Exponential mechanism.

--- a/validator-rust/src/components/count.rs
+++ b/validator-rust/src/components/count.rs
@@ -6,7 +6,7 @@ use std::collections::HashMap;
 use crate::{proto, base};
 
 use crate::components::{Component, Aggregator};
-use crate::base::{Value, NodeProperties, AggregatorProperties, Vector2DJagged, Sensitivity, ValueProperties, prepend, DataType};
+use crate::base::{Value, NodeProperties, AggregatorProperties, Sensitivity, ValueProperties, prepend, DataType};
 
 impl Component for proto::Count {
     // modify min, max, n, categories, is_public, non-null, etc. based on the arguments and component
@@ -27,6 +27,7 @@ impl Component for proto::Count {
         });
 
         data_property.num_records = Some(1);
+        data_property.num_columns = Some(1);
         data_property.nature = None;
         data_property.data_type = DataType::I64;
 
@@ -44,60 +45,45 @@ impl Component for proto::Count {
 impl Aggregator for proto::Count {
     fn compute_sensitivity(
         &self,
-        _privacy_definition: &proto::PrivacyDefinition,
+        privacy_definition: &proto::PrivacyDefinition,
         properties: &NodeProperties,
         sensitivity_type: &Sensitivity
     ) -> Result<Vec<f64>> {
-        let data_property = properties.get("data")
-            .ok_or("data: missing")?.get_arraynd()
-            .map_err(prepend("data:"))?.clone();
-
-        data_property.assert_is_not_aggregated()?;
-
-        let num_columns = data_property.get_num_columns()?;
 
         match sensitivity_type {
 
             Sensitivity::KNorm(k) => {
-                if k != &1 {
-                    return Err("Count sensitivity is only implemented for KNorm of 1".into())
-                }
-                // if n is set, and the number of categories is 2, then sensitivity is 1.
-                // Otherwise, sensitivity is 2 (changing one person can alter two bins)
-                Ok(match data_property.get_num_records() {
-                    // known n
-                    Ok(_num_records) => match data_property.get_categories() {
-                        // by known categories
-                        Ok(categories) => get_lengths(&categories).iter()
-                            .map(|column_length| if column_length <= &2 {1.} else {2.})
-                            .collect(),
+                let data_property = properties.get("data")
+                    .ok_or("data: missing")?.get_arraynd()
+                    .map_err(prepend("data:"))?.clone();
 
-                        // categories not set (useless: noisy estimate of number of rows, when number of rows is known)
-                        Err(_) => (0..num_columns).map(|_| 1.).collect()
-                    },
-                    // unknown n
-                    Err(_) => match data_property.get_categories() {
-                        // by known categories
-                        Ok(_categories) => (0..num_columns).map(|_| 2.).collect(),
-                        // categories not set (estimate of number of rows)
-                        Err(_) => (0..num_columns).map(|_| 1.).collect(),
+                data_property.assert_is_not_aggregated()?;
+                let sensitivity = if data_property.get_num_records().is_ok() {
+                    // sensitivity is zero, because changing records has no effect on n after data is resized
+                    0.
+                } else {
+                    use proto::privacy_definition::Neighboring;
+                    let neighboring_type = Neighboring::from_i32(privacy_definition.neighboring)
+                        .ok_or::<Error>("neighboring definition must be either \"AddRemove\" or \"Substitute\"".into())?;
+
+                    // All cases are intentionally enumerated
+                    match neighboring_type {
+                        Neighboring::Substitute => match k {
+                            1 => 1.,
+                            2 => 1.,
+                            _ => return Err("Count sensitivity is only implemented for L1 and L2 spaces".into())
+                        },
+                        Neighboring::AddRemove => match k {
+                            1 => 1.,
+                            2 => 1.,
+                            _ => return Err("Count sensitivity is only implemented for L1 and L2 spaces".into())
+                        }
                     }
-                })
-            },
-            _ => return Err("Count sensitivity is only implemented for KNorm of 1".into())
-        }
-    }
-}
+                };
 
-fn get_lengths(value: &Vector2DJagged) -> Vec<i64> {
-    match value {
-        Vector2DJagged::Bool(value) => value.iter()
-            .map(|column| column.clone().unwrap().len() as i64).collect(),
-        Vector2DJagged::F64(value) => value.iter()
-            .map(|column| column.clone().unwrap().len() as i64).collect(),
-        Vector2DJagged::I64(value) => value.iter()
-            .map(|column| column.clone().unwrap().len() as i64).collect(),
-        Vector2DJagged::Str(value) => value.iter()
-            .map(|column| column.clone().unwrap().len() as i64).collect()
+                Ok(vec![sensitivity])
+            },
+            _ => return Err("Count sensitivity is only implemented for KNorm".into())
+        }
     }
 }

--- a/validator-rust/src/components/covariance.rs
+++ b/validator-rust/src/components/covariance.rs
@@ -16,26 +16,24 @@ impl Component for proto::Covariance {
         _public_arguments: &HashMap<String, Value>,
         properties: &base::NodeProperties,
     ) -> Result<ValueProperties> {
-
         if properties.contains_key("data") {
             let mut data_property = properties.get("data")
                 .ok_or("data: missing")?.get_arraynd()
                 .map_err(prepend("data:"))?.clone();
 
-            data_property.assert_is_not_aggregated()?;
-
             // save a snapshot of the state when aggregating
             data_property.aggregator = Some(AggregatorProperties {
                 component: proto::component::Variant::from(self.clone()),
-                properties: properties.clone()
+                properties: properties.clone(),
             });
 
-            data_property.num_records = data_property.num_columns.clone();
+            let num_columns = data_property.get_num_columns()?;
+            data_property.num_records = Some(1);
+            data_property.num_columns = Some(num_columns * (num_columns + 1) / 2);
 
             // min/max of data is not known after computing covariance
             data_property.nature = None;
             return Ok(data_property.into());
-
         } else if properties.contains_key("left") && properties.contains_key("right") {
             let mut left_property = properties.get("left")
                 .ok_or("left: missing")?.get_arraynd()
@@ -45,22 +43,28 @@ impl Component for proto::Covariance {
                 .ok_or("right: missing")?.get_arraynd()
                 .map_err(prepend("right:"))?.clone();
 
-            left_property.assert_is_not_aggregated()?;
-            right_property.assert_is_not_aggregated()?;
-
             // save a snapshot of the state when aggregating
             left_property.aggregator = Some(AggregatorProperties {
                 component: proto::component::Variant::from(self.clone()),
-                properties: properties.clone()
+                properties: properties.clone(),
             });
+
+            let left_n = left_property.get_num_records()?;
+            let right_n = right_property.get_num_records()?;
+
+            if left_n != right_n {
+                return Err("n for left and right must be equivalent".into());
+            }
 
             left_property.nature = None;
             left_property.releasable = left_property.releasable && right_property.releasable;
 
-            return Ok(left_property.into());
+            left_property.num_records = Some(1);
+            left_property.num_columns = Some(left_property.get_num_columns()? * right_property.get_num_columns()?);
 
+            return Ok(left_property.into());
         } else {
-            return Err("either \"data\" for covariance, or \"left\" and \"right\" for cross-covariance must be supplied".into())
+            return Err("either \"data\" for covariance, or \"left\" and \"right\" for cross-covariance must be supplied".into());
         }
     }
 
@@ -75,60 +79,93 @@ impl Component for proto::Covariance {
 impl Aggregator for proto::Covariance {
     fn compute_sensitivity(
         &self,
-        _privacy_definition: &proto::PrivacyDefinition,
+        privacy_definition: &proto::PrivacyDefinition,
         properties: &NodeProperties,
-        sensitivity_type: &Sensitivity
+        sensitivity_type: &Sensitivity,
     ) -> Result<Vec<f64>> {
-        let mut left_property = properties.get("left")
-            .ok_or("left: missing")?.get_arraynd()
-            .map_err(prepend("left:"))?.clone();
-
-        let right_property = properties.get("right")
-            .ok_or("right: missing")?.get_arraynd()
-            .map_err(prepend("right:"))?.clone();
 
         match sensitivity_type {
             Sensitivity::KNorm(k) => {
-                if k != &1 {
-                    return Err("Covariance sensitivity is only implemented for KNorm of 1".into())
-                }
 
-                // check that all properties are satisfied
-//                println!("covariance left");
-                let left_n = left_property.get_num_records()?;
-                left_property.get_min_f64()?;
-                left_property.get_max_f64()?;
-                left_property.assert_non_null()?;
+                let data_n;
+                let differences = match (properties.get("data"), properties.get("left"), properties.get("right")) {
+                    (Some(data_property), None, None) => {
 
-                // check that all properties are satisfied
-//                println!("covariance right");
-                let right_n = right_property.get_num_records()?;
-                right_property.get_min_f64()?;
-                right_property.get_max_f64()?;
-                right_property.assert_non_null()?;
+                        // data: perform checks and prepare parameters
+                        let data_property = data_property.get_arraynd()
+                            .map_err(prepend("data:"))?.clone();
+                        data_property.assert_is_not_aggregated()?;
+                        data_property.assert_non_null()?;
+                        let data_min = data_property.get_min_f64()?;
+                        let data_max = data_property.get_max_f64()?;
+                        data_n = data_property.get_num_records()? as f64;
 
-                if left_n != right_n {
-                    return Err("n for left and right must be equivalent".into());
-                }
+                        // collect bound differences for upper triangle of matrix
+                        data_min.iter().zip(data_max.iter()).enumerate()
+                            .map(|(i, (left_min, left_max))| data_min.iter().zip(data_max.iter()).enumerate()
+                                .filter(|(j, _)| i <= *j)
+                                .map(|(_, (right_min, right_max))|
+                                    (*left_max - *left_min) * (*right_max - *right_min))
+                                .collect::<Vec<f64>>()).flat_map(|s| s).collect::<Vec<f64>>()
+                    },
+                    (None, Some(left_property), Some(right_property)) => {
 
-                // TODO: derive proper propagation of covariance property
-                left_property.num_records = Some(1);
-                left_property.releasable = true;
+                        // left side: perform checks and prepare parameters
+                        let left_property = left_property.get_arraynd()
+                            .map_err(prepend("left:"))?.clone();
+                        left_property.assert_is_not_aggregated()?;
+                        left_property.assert_non_null()?;
+                        let left_n = left_property.get_num_records()?;
+                        let left_min = left_property.get_min_f64()?;
+                        let left_max = left_property.get_max_f64()?;
 
-                // TODO: cross-covariance
-                let data_property = properties.get("data")
-                    .ok_or("data: missing")?.get_arraynd()
-                    .map_err(prepend("data:"))?.clone();
+                        // right side: perform checks and prepare parameters
+                        let right_property = right_property.get_arraynd()
+                            .map_err(prepend("right:"))?.clone();
+                        right_property.assert_is_not_aggregated()?;
+                        right_property.assert_non_null()?;
+                        let right_n = right_property.get_num_records()?;
+                        let right_min = right_property.get_min_f64()?;
+                        let right_max = right_property.get_max_f64()?;
 
-                let min = data_property.get_min_f64()?;
-                let max = data_property.get_max_f64()?;
+                        // ensure conformability
+                        if left_n != right_n {
+                            return Err("n for left and right must be equivalent".into());
+                        }
+                        data_n = left_n as f64;
 
-                Ok(min.iter()
-                    .zip(max)
-                    .map(|(min, max)| (max - min) as f64)
+                        // collect bound differences for entire matrix
+                        left_min.clone().iter().zip(left_max.clone())
+                            .map(|(left_min, left_max)| right_min.iter().zip(right_max.iter())
+                                .map(|(right_min, right_max)|
+                                    (left_max - *left_min) * (right_max - *right_min))
+                                .collect::<Vec<f64>>())
+                            .flat_map(|s| s).collect::<Vec<f64>>()
+                    }
+                    _ => return Err("either \"data\" or \"left\" and \"right\" must be supplied".into())
+                };
+
+                let delta_degrees_of_freedom = if self.finite_sample_correction { 1 } else { 0 } as f64;
+                let normalization = data_n - delta_degrees_of_freedom;
+
+                use proto::privacy_definition::Neighboring;
+                let neighboring_type = Neighboring::from_i32(privacy_definition.neighboring)
+                    .ok_or::<Error>("neighboring definition must be either \"AddRemove\" or \"Substitute\"".into())?;
+
+                let scaling_constant: f64 = match k {
+                    1 | 2 => match neighboring_type {
+                        Neighboring::AddRemove => data_n / (data_n + 1.) / normalization,
+                        Neighboring::Substitute => 2. * (data_n - 1.) / data_n / normalization
+                    },
+                    _ => return Err("KNorm sensitivity is only supported in L1 and L2 spaces".into())
+                };
+
+                Ok(differences.iter()
+                    .map(|difference| (difference * scaling_constant).powi(*k as i32))
                     .collect())
             },
-            _ => return Err("Covariance sensitivity is only implemented for KNorm of 1".into())
+            _ => Err("Covariance sensitivity is only implemented for KNorm".into())
         }
+
     }
 }

--- a/validator-rust/src/components/dp_covariance.rs
+++ b/validator-rust/src/components/dp_covariance.rs
@@ -10,6 +10,7 @@ use crate::components::{Component, Accuracy, Expandable, Report};
 
 use crate::base::{NodeProperties, Value, ValueProperties, prepend};
 use crate::utilities::json::{JSONRelease, value_to_json, AlgorithmInfo, privacy_usage_to_json};
+use std::convert::TryFrom;
 
 
 impl Component for proto::DpCovariance {
@@ -36,41 +37,86 @@ impl Expandable for proto::DpCovariance {
         &self,
         _privacy_definition: &proto::PrivacyDefinition,
         component: &proto::Component,
-        _properties: &base::NodeProperties,
+        properties: &base::NodeProperties,
         component_id: u32,
         maximum_id: u32,
     ) -> Result<proto::ComponentExpansion> {
         let mut current_id = maximum_id.clone();
         let mut computation_graph: HashMap<u32, proto::Component> = HashMap::new();
 
+        let arguments;
+        let shape;
+        let symmetric;
+        match properties.get("data") {
+            Some(data_property) => {
+                let data_property = data_property.get_arraynd()
+                    .map_err(prepend("data:"))?.clone();
+
+                let num_columns = data_property.get_num_columns()?;
+                shape = vec![u32::try_from(num_columns).unwrap(), u32::try_from(num_columns).unwrap()];
+                arguments = hashmap![
+                    "data".to_owned() => *component.arguments.get("data").ok_or::<Error>("data must be provided as an argument".into())?
+                ];
+                symmetric = true;
+            },
+            None => {
+                let left_property = properties.get("left")
+                    .ok_or("data: missing")?.get_arraynd()
+                    .map_err(prepend("data:"))?.clone();
+                let right_property = properties.get("right")
+                    .ok_or("data: missing")?.get_arraynd()
+                    .map_err(prepend("data:"))?.clone();
+
+                shape = vec![u32::try_from(left_property.get_num_columns()?).unwrap(), u32::try_from(right_property.get_num_columns()?).unwrap()];
+                arguments = hashmap![
+                    "left".to_owned() => *component.arguments.get("left").ok_or::<Error>("left must be provided as an argument".into())?,
+                    "right".to_owned() => *component.arguments.get("right").ok_or::<Error>("right must be provided as an argument".into())?
+                ];
+                symmetric = false;
+            }
+        };
+
         // covariance
         current_id += 1;
         let id_covariance = current_id.clone();
         computation_graph.insert(id_covariance, proto::Component {
-            arguments: hashmap![
-                "left".to_owned() => *component.arguments.get("left").unwrap(),
-                "right".to_owned() => *component.arguments.get("right").unwrap()
-            ],
-            variant: Some(proto::component::Variant::from(proto::Covariance {})),
+            arguments,
+            variant: Some(proto::component::Variant::from(proto::Covariance {
+                finite_sample_correction: self.finite_sample_correction
+            })),
             omit: true,
             batch: component.batch,
         });
 
         // noise
-        computation_graph.insert(component_id, proto::Component {
+        current_id += 1;
+        let id_noise = current_id.clone();
+        computation_graph.insert(id_noise, proto::Component {
             arguments: hashmap!["data".to_owned() => id_covariance],
             variant: Some(proto::component::Variant::from(proto::LaplaceMechanism {
                 privacy_usage: self.privacy_usage.clone()
             })),
-            omit: false,
+            omit: true,
             batch: component.batch,
+        });
+
+        // reshape into matrix
+        computation_graph.insert(component_id, proto::Component {
+            arguments: hashmap!["data".to_owned() => id_noise],
+            variant: Some(proto::component::Variant::from(proto::Reshape {
+                symmetric,
+                layout: "row".to_string(),
+                shape
+            })),
+            omit: false,
+            batch: component.batch
         });
 
         Ok(proto::ComponentExpansion {
             computation_graph,
             properties: HashMap::new(),
             releases: HashMap::new(),
-            traversal: vec![id_covariance]
+            traversal: vec![id_covariance, id_noise]
         })
     }
 }
@@ -104,47 +150,65 @@ impl Report for proto::DpCovariance {
         release: &Value
     ) -> Result<Option<Vec<JSONRelease>>> {
 
-        let data_property = properties.get("data")
-            .ok_or("data: missing")?.get_arraynd()
-            .map_err(prepend("data:"))?.clone();
+        let argument;
+        let statistic;
 
-        let mut releases = Vec::new();
+        if properties.contains_key("data") {
+            let data_property = properties.get("data")
+                .ok_or("data: missing")?.get_arraynd()
+                .map_err(prepend("data:"))?.clone();
 
-        let minimums = data_property.get_min_f64().unwrap();
-        let maximums = data_property.get_max_f64().unwrap();
-        let num_records = data_property.get_num_records().unwrap();
-
-        for column_number in 0..data_property.num_columns.unwrap() {
-
-            let mut release_info = HashMap::new();
-            release_info.insert("mechanism".to_string(), serde_json::json!(self.implementation.clone()));
-            release_info.insert("releaseValue".to_string(), value_to_json(&release).unwrap());
-
-            let release = JSONRelease {
-                description: "DP release information".to_string(),
-                statistic: "DPCovariance".to_string(),
-                variables: vec![],
-                release_info,
-                privacy_loss: privacy_usage_to_json(&self.privacy_usage[column_number as usize].clone()),
-                accuracy: None,
-                batch: component.batch as u64,
-                node_id: node_id.clone() as u64,
-                postprocess: false,
-                algorithm_info: AlgorithmInfo {
-                    name: "".to_string(),
-                    cite: "".to_string(),
-                    argument: serde_json::json!({
-                        "n": num_records,
-                        "constraint": {
-                            "lowerbound": minimums[column_number as usize],
-                            "upperbound": maximums[column_number as usize]
-                        }
-                    })
+            statistic = "DPCovariance".to_string();
+            argument = serde_json::json!({
+                "n": data_property.get_num_records()?,
+                "constraint": {
+                    "lowerbound": data_property.get_min_f64()?,
+                    "upperbound": data_property.get_max_f64()?
                 }
-            };
-
-            releases.push(release);
+            });
         }
-        Ok(Some(releases))
+        else {
+            let left_property = properties.get("left")
+                .ok_or("data: missing")?.get_arraynd()
+                .map_err(prepend("data:"))?.clone();
+            let right_property = properties.get("right")
+                .ok_or("data: missing")?.get_arraynd()
+                .map_err(prepend("data:"))?.clone();
+
+            statistic = "DPCrossCovariance".to_string();
+            argument = serde_json::json!({
+                "n": left_property.get_num_records()?,
+                "constraint": {
+                    "lowerbound_left": left_property.get_min_f64()?,
+                    "upperbound_left": left_property.get_max_f64()?,
+                    "lowerbound_right": right_property.get_min_f64()?,
+                    "upperbound_right": right_property.get_max_f64()?
+                }
+            });
+        }
+
+        let mut release_info = HashMap::new();
+        release_info.insert("mechanism".to_string(), serde_json::json!(self.implementation.clone()));
+        release_info.insert("releaseValue".to_string(), value_to_json(&release)?);
+
+        let privacy_usage: Vec<serde_json::Value> = self.privacy_usage.iter().map(privacy_usage_to_json).clone().collect();
+
+
+        Ok(Some(vec![JSONRelease {
+            description: "DP release information".to_string(),
+            statistic,
+            variables: vec![],
+            release_info,
+            privacy_loss: serde_json::json![privacy_usage],
+            accuracy: None,
+            batch: component.batch as u64,
+            node_id: node_id.clone() as u64,
+            postprocess: false,
+            algorithm_info: AlgorithmInfo {
+                name: "".to_string(),
+                cite: "".to_string(),
+                argument
+            }
+        }]))
     }
 }

--- a/validator-rust/src/components/dp_histogram.rs
+++ b/validator-rust/src/components/dp_histogram.rs
@@ -132,14 +132,14 @@ impl Report for proto::DpHistogram {
 
         let mut releases = Vec::new();
 
-        let minimums = data_property.get_min_f64().unwrap();
-        let maximums = data_property.get_max_f64().unwrap();
-        let num_records = data_property.get_num_records().unwrap();
+        let minimums = data_property.get_min_f64()?;
+        let maximums = data_property.get_max_f64()?;
+        let num_records = data_property.get_num_records()?;
 
-        for column_number in 0..data_property.num_columns.unwrap() {
+        for column_number in 0..data_property.get_num_columns()? {
             let mut release_info = HashMap::new();
             release_info.insert("mechanism".to_string(), serde_json::json!(self.implementation.clone()));
-            release_info.insert("releaseValue".to_string(), value_to_json(&release).unwrap());
+            release_info.insert("releaseValue".to_string(), value_to_json(&release)?);
 
             let release = JSONRelease {
                 description: "DP release information".to_string(),

--- a/validator-rust/src/components/dp_maximum.rs
+++ b/validator-rust/src/components/dp_maximum.rs
@@ -7,7 +7,7 @@ use crate::{proto, base};
 use crate::hashmap;
 use crate::components::{Component, Accuracy, Expandable, Report};
 
-use crate::base::{NodeProperties, Value, ValueProperties, prepend};
+use crate::base::{NodeProperties, Value, ValueProperties, prepend, broadcast_privacy_usage};
 use crate::utilities::json::{JSONRelease, AlgorithmInfo, privacy_usage_to_json, value_to_json};
 
 impl Component for proto::DpMaximum {
@@ -50,12 +50,12 @@ impl Expandable for proto::DpMaximum {
             batch: component.batch,
         });
 
-        let id_candidates = component.arguments.get("candidates").unwrap().clone();
+//        let id_candidates = component.arguments.get("candidates").unwrap().clone();
 
         // sanitizing
         computation_graph.insert(component_id, proto::Component {
-            arguments: hashmap!["data".to_owned() => id_maximum, "candidates".to_owned() => id_candidates.clone()],
-            variant: Some(proto::component::Variant::from(proto::ExponentialMechanism {
+            arguments: hashmap!["data".to_owned() => id_maximum],
+            variant: Some(proto::component::Variant::from(proto::LaplaceMechanism {
                 privacy_usage: self.privacy_usage.clone()
             })),
             omit: false,
@@ -105,20 +105,23 @@ impl Report for proto::DpMaximum {
 
         let mut releases = Vec::new();
 
-        let minimums = data_property.get_min_f64().unwrap();
-        let maximums = data_property.get_max_f64().unwrap();
+        let minimums = data_property.get_min_f64()?;
+        let maximums = data_property.get_max_f64()?;
 
-        for column_number in 0..data_property.num_columns.unwrap() {
+        let num_columns = data_property.get_num_columns()?;
+        let privacy_usages = broadcast_privacy_usage(&self.privacy_usage, num_columns as usize)?;
+
+        for column_number in 0..num_columns {
             let mut release_info = HashMap::new();
             release_info.insert("mechanism".to_string(), serde_json::json!(self.implementation.clone()));
-            release_info.insert("releaseValue".to_string(), value_to_json(&release).unwrap());
+            release_info.insert("releaseValue".to_string(), value_to_json(&release)?);
 
             let release = JSONRelease {
                 description: "DP release information".to_string(),
                 statistic: "DPMaximum".to_string(),
                 variables: vec![],
                 release_info,
-                privacy_loss: privacy_usage_to_json(&self.privacy_usage[column_number as usize].clone()),
+                privacy_loss: privacy_usage_to_json(&privacy_usages[column_number as usize].clone()),
                 accuracy: None,
                 batch: component.batch as u64,
                 node_id: node_id.clone() as u64,

--- a/validator-rust/src/components/dp_mean.rs
+++ b/validator-rust/src/components/dp_mean.rs
@@ -8,7 +8,7 @@ use crate::hashmap;
 use crate::components::{Component, Accuracy, Expandable, Report};
 
 
-use crate::base::{NodeProperties, Value, ValueProperties, prepend};
+use crate::base::{NodeProperties, Value, ValueProperties, prepend, broadcast_privacy_usage};
 use crate::utilities::json::{JSONRelease, AlgorithmInfo, privacy_usage_to_json, value_to_json};
 
 use serde_json;
@@ -65,7 +65,7 @@ impl Expandable for proto::DpMean {
         current_id += 1;
         let id_mean = current_id.clone();
         computation_graph.insert(id_mean, proto::Component {
-            arguments: hashmap!["data".to_owned() => *component.arguments.get("data").unwrap()],
+            arguments: hashmap!["data".to_owned() => *component.arguments.get("data").ok_or::<Error>("data must be provided as an argument".into())?],
             variant: Some(proto::component::Variant::Mean(proto::Mean {})),
             omit: true,
             batch: component.batch,
@@ -145,22 +145,23 @@ impl Report for proto::DpMean {
 
         let mut releases = Vec::new();
 
-        let minimums = data_property.get_min_f64().unwrap();
-        let maximums = data_property.get_max_f64().unwrap();
-        let num_records = data_property.get_num_records().unwrap();
+        let minimums = data_property.get_min_f64()?;
+        let maximums = data_property.get_max_f64()?;
+        let num_records = data_property.get_num_records()?;
+        let privacy_usages = broadcast_privacy_usage(&self.privacy_usage, num_records as usize)?;
 
-        for column_number in 0..data_property.num_columns.unwrap() {
+        for column_number in 0..data_property.get_num_columns()? {
 
             let mut release_info = HashMap::new();
             release_info.insert("mechanism".to_string(), serde_json::json!(self.implementation.clone()));
-            release_info.insert("releaseValue".to_string(), value_to_json(&release).unwrap());
+            release_info.insert("releaseValue".to_string(), value_to_json(&release)?);
 
             let release = JSONRelease {
                 description: "DP release information".to_string(),
                 statistic: "DPMean".to_string(),
                 variables: vec![],
                 release_info,
-                privacy_loss: privacy_usage_to_json(&self.privacy_usage[column_number as usize].clone()),
+                privacy_loss: privacy_usage_to_json(&privacy_usages[column_number as usize].clone()),
                 accuracy: None,
                 batch: component.batch as u64,
                 node_id: node_id.clone() as u64,

--- a/validator-rust/src/components/dp_sum.rs
+++ b/validator-rust/src/components/dp_sum.rs
@@ -6,7 +6,7 @@ use crate::{proto, base};
 use crate::hashmap;
 use crate::components::{Component, Accuracy, Expandable, Report};
 
-use crate::base::{NodeProperties, Value, ValueProperties, prepend};
+use crate::base::{NodeProperties, Value, ValueProperties, prepend, broadcast_privacy_usage};
 use crate::utilities::json::{JSONRelease, AlgorithmInfo, privacy_usage_to_json, value_to_json};
 
 impl Component for proto::DpSum {
@@ -44,7 +44,7 @@ impl Expandable for proto::DpSum {
         current_id += 1;
         let id_sum = current_id.clone();
         computation_graph.insert(id_sum, proto::Component {
-            arguments: hashmap!["data".to_owned() => *component.arguments.get("data").unwrap()],
+            arguments: hashmap!["data".to_owned() => *component.arguments.get("data").ok_or::<Error>("data must be provided as an argument".into())?],
             variant: Some(proto::component::Variant::Sum(proto::Sum {})),
             omit: true,
             batch: component.batch,
@@ -103,20 +103,24 @@ impl Report for proto::DpSum {
 
         let mut releases = Vec::new();
 
-        let minimums = data_property.get_min_f64().unwrap();
-        let maximums = data_property.get_max_f64().unwrap();
+        let minimums = data_property.get_min_f64()?;
+        let maximums = data_property.get_max_f64()?;
 
-        for column_number in 0..data_property.num_columns.unwrap() {
+        let num_columns = data_property.get_num_columns()?;
+        let privacy_usages = broadcast_privacy_usage(&self.privacy_usage, num_columns as usize)?;
+
+
+        for column_number in 0..num_columns {
             let mut release_info = HashMap::new();
             release_info.insert("mechanism".to_string(), serde_json::json!(self.implementation.clone()));
-            release_info.insert("releaseValue".to_string(), value_to_json(&release).unwrap());
+            release_info.insert("releaseValue".to_string(), value_to_json(&release)?);
 
             let release = JSONRelease {
                 description: "DP release information".to_string(),
                 statistic: "DPSum".to_string(),
                 variables: vec![],
                 release_info,
-                privacy_loss: privacy_usage_to_json(&self.privacy_usage[column_number as usize].clone()),
+                privacy_loss: privacy_usage_to_json(&privacy_usages[column_number as usize].clone()),
                 accuracy: None,
                 batch: component.batch as u64,
                 node_id: node_id.clone() as u64,

--- a/validator-rust/src/components/dp_variance.rs
+++ b/validator-rust/src/components/dp_variance.rs
@@ -8,7 +8,7 @@ use crate::hashmap;
 use crate::components::{Component, Accuracy, Expandable, Report};
 
 
-use crate::base::{NodeProperties, Value, ValueProperties, prepend};
+use crate::base::{NodeProperties, Value, ValueProperties, prepend, broadcast_privacy_usage};
 use crate::utilities::json::{JSONRelease, AlgorithmInfo, privacy_usage_to_json, value_to_json};
 
 
@@ -47,7 +47,7 @@ impl Expandable for proto::DpVariance {
         current_id += 1;
         let id_variance = current_id.clone();
         computation_graph.insert(id_variance, proto::Component {
-            arguments: hashmap!["data".to_owned() => *component.arguments.get("data").unwrap()],
+            arguments: hashmap!["data".to_owned() => *component.arguments.get("data").ok_or::<Error>("data must be provided as an argument".into())?],
             variant: Some(proto::component::Variant::from(proto::Variance {
                 finite_sample_correction: self.finite_sample_correction
             })),
@@ -108,21 +108,24 @@ impl Report for proto::DpVariance {
 
         let mut releases = Vec::new();
 
-        let minimums = data_property.get_min_f64().unwrap();
-        let maximums = data_property.get_max_f64().unwrap();
-        let num_records = data_property.get_num_records().unwrap();
+        let minimums = data_property.get_min_f64()?;
+        let maximums = data_property.get_max_f64()?;
+        let num_records = data_property.get_num_records()?;
 
-        for column_number in 0..data_property.num_columns.unwrap() {
+        let num_columns = data_property.get_num_columns()?;
+        let privacy_usages = broadcast_privacy_usage(&self.privacy_usage, num_columns as usize)?;
+
+        for column_number in 0..num_columns {
             let mut release_info = HashMap::new();
             release_info.insert("mechanism".to_string(), serde_json::json!(self.implementation.clone()));
-            release_info.insert("releaseValue".to_string(), value_to_json(&release).unwrap());
+            release_info.insert("releaseValue".to_string(), value_to_json(&release)?);
 
             let release = JSONRelease {
                 description: "DP release information".to_string(),
                 statistic: "DPVariance".to_string(),
                 variables: vec![],
                 release_info,
-                privacy_loss: privacy_usage_to_json(&self.privacy_usage[column_number as usize].clone()),
+                privacy_loss: privacy_usage_to_json(&privacy_usages[column_number as usize].clone()),
                 accuracy: None,
                 batch: component.batch as u64,
                 node_id: node_id.clone() as u64,

--- a/validator-rust/src/components/filter.rs
+++ b/validator-rust/src/components/filter.rs
@@ -38,6 +38,9 @@ impl Component for proto::Filter {
         // the number of records is not known after filtering rows
         data_property.num_records = None;
 
+        // This exists to prevent binary ops on non-conformable arrays from being approved
+        data_property.dataset_id = None;
+
         Ok(data_property.into())
     }
 

--- a/validator-rust/src/components/index.rs
+++ b/validator-rust/src/components/index.rs
@@ -1,15 +1,14 @@
 use crate::errors::*;
 
 use std::collections::HashMap;
-use crate::base::{ArrayND, Value, NodeProperties, ValueProperties, prepend, Hashmap};
+use crate::base::{ArrayND, Value, NodeProperties, ValueProperties, Hashmap, ArrayNDProperties, Nature, NatureContinuous, NatureCategorical, Vector1DNull, Vector2DJagged};
 
 use crate::{proto, base};
 use crate::components::Component;
 
 use std::ops::Deref;
-
-// TODO: this could use additional checks to prevent out of bounds
-
+use ndarray::ArrayD;
+use ndarray::prelude::*;
 
 impl Component for proto::Index {
     // modify min, max, n, categories, is_public, non-null, etc. based on the arguments and component
@@ -20,37 +19,87 @@ impl Component for proto::Index {
         properties: &base::NodeProperties,
     ) -> Result<ValueProperties> {
         let data_property = properties.get("data")
-            .ok_or("data: missing")?.get_hashmap()
-            .map_err(prepend("data:"))?.clone();
+            .ok_or("data: missing")?.clone();
 
-        let columns = public_arguments.get("columns")
+        let column_names = public_arguments.get("columns")
             .ok_or::<Error>("columns: missing".into())?.deref().to_owned().get_arraynd()?.clone();
 
-        match (data_property.value_properties, columns) {
-            (Hashmap::Str(value_properties), ArrayND::Str(column_names)) => {
-                let all_properties = column_names.iter()
-                    .map(|v| value_properties.get(v))
-                    .collect::<Option<Vec<&ValueProperties>>>()
-                    .ok_or::<Error>("columns: unknown column in index".into())?;
+        let properties = match data_property {
+            ValueProperties::Hashmap(data_property) => {
+                // TODO: check that hashmap is columnar. The columnar property is in another branch.
+                //       when partition is added, should we allow column stacking of partitions?
+                match data_property.value_properties {
+                    Hashmap::Str(value_properties) => match column_names {
+                        // String column names on string hashmap
+                        ArrayND::Str(column_names) => to_name_vec(&column_names)?.into_iter()
+                            .map(|v| value_properties.get(&v).cloned())
+                            .collect::<Option<Vec<ValueProperties>>>()
+                            .ok_or::<Error>("columns: unknown column in index".into()),
+                        // Bool mask on string hashmap
+                        ArrayND::Bool(column_names) => {
+                            let mask = to_name_vec(&column_names)?;
+                            if value_properties.len() != mask.len() {
+                                return Err("mask must be the same length as the number of columns".into());
+                            }
 
-                if all_properties.len() != 1 {
-                    return Err("columns: only one column may be selected at this time".into())
+                            Ok(mask.into_iter()
+                                .zip(value_properties.values())
+                                .filter(|(mask, _)| *mask)
+                                .map(|(_, value)| value.clone())
+                                .collect())
+                        },
+                        // Indices on string hashmap
+                        ArrayND::I64(indices) => {
+                            let indices = to_name_vec(&indices)?;
+                            let column_names = value_properties.keys().cloned().collect::<Vec<String>>();
+                            indices.iter().map(|index| value_properties.get(column_names.get(*index as usize)
+                                .ok_or::<Error>("column index is out of range".into())?).cloned()
+                                .ok_or::<Error>("properties not found".into())).collect::<Result<Vec<ValueProperties>>>()
+                        },
+                        ArrayND::F64(_) => Err("columns may not have float type".into())
+                    },
+                    Hashmap::I64(value_properties) => match column_names {
+                        // I64 column names on I64 hashmap
+                        ArrayND::I64(column_names) => to_name_vec(&column_names)?.into_iter()
+                            .map(|v| value_properties.get(&v).cloned())
+                            .collect::<Option<Vec<ValueProperties>>>()
+                            .ok_or::<Error>("columns: unknown column in index".into()),
+                        // Bool mask on I64 hashmap
+                        ArrayND::Bool(column_names) => {
+                            let mask = to_name_vec(&column_names)?;
+                            if value_properties.len() != mask.len() {
+                                return Err("mask must be the same length as the number of columns".into());
+                            }
+
+                            Ok(mask.into_iter()
+                                .zip(value_properties.values())
+                                .filter(|(mask, _)| *mask)
+                                .map(|(_, value)| value.clone())
+                                .collect())
+                        },
+                        _ => Err("columns must be either integer or a boolean mask".into())
+                    },
+                    Hashmap::Bool(value_properties) =>
+                        to_name_vec(column_names.get_bool()?)?.into_iter()
+                            .map(|name| value_properties.get(&name).cloned()
+                                .ok_or::<Error>("columns: unknown column in index".into()))
+                            .collect::<Result<Vec<ValueProperties>>>()
                 }
-                Ok(all_properties.first().unwrap().clone().clone())
             },
-            (Hashmap::I64(value_properties), ArrayND::I64(column_indices)) => {
-                let all_properties = column_indices.iter()
-                    .map(|v| value_properties.get(v))
-                    .collect::<Option<Vec<&ValueProperties>>>()
-                    .ok_or::<Error>("columns: unknown column in index".into())?;
+            ValueProperties::ArrayND(data_property) => match column_names {
+                ArrayND::I64(indices) => to_name_vec(&indices)?.into_iter()
+                    .map(|index| select_properties(&data_property, &(index as usize)))
+                    .collect::<Result<Vec<ValueProperties>>>(),
+                ArrayND::Bool(mask) => to_name_vec(&mask)?.into_iter()
+                    .enumerate().filter(|(_, mask)| *mask)
+                    .map(|(idx, _)| select_properties(&data_property, &idx))
+                    .collect::<Result<Vec<ValueProperties>>>(),
+                _ => return Err("the data type of the indices are not supported".into())
+            },
+            ValueProperties::Vector2DJagged(_) => Err("indexing is not supported on vectors".into())
+        }?;
 
-                if all_properties.len() != 1 {
-                    return Err("columns: only one column may be selected at this time".into())
-                }
-                Ok(all_properties.first().unwrap().clone().clone())
-            }
-            _ => return Err("columns must be strings or integers".into())
-        }
+        stack_properties(&properties)
     }
 
     fn get_names(
@@ -59,4 +108,109 @@ impl Component for proto::Index {
     ) -> Result<Vec<String>> {
         Err("get_names not implemented".into())
     }
+}
+
+
+pub fn to_name_vec<T: Clone>(columns: &ArrayD<T>) -> Result<Vec<T>> {
+    match columns.ndim().clone() {
+        0 => Ok(vec![columns.first().ok_or::<Error>("At least one column name must be supplied".into())?.clone()]),
+        1 => match columns.clone().into_dimensionality::<Ix1>() {
+            Ok(columns) => Ok(columns.to_vec()),
+            Err(_) => Err("column names must be 1-dimensional".into())
+        },
+        _ => Err("dimensionality of column names must be less than 2".into())
+    }
+}
+
+pub fn mask_columns<T: Clone>(column_names: &Vec<T>, mask: &Vec<bool>) -> Result<Vec<T>> {
+    if mask.len() != column_names.len() {
+        return Err("boolean mask must be the same length as the column names".into());
+    }
+    Ok(column_names.iter().zip(mask)
+        .filter(|(_, mask)| **mask)
+        .map(|(name, _)| name.to_owned())
+        .collect::<Vec<T>>())
+}
+
+fn take<T: Clone>(vector: &Vec<T>, index: &usize) -> Result<T> {
+    match vector.get(*index) {
+        Some(value) => Ok(value.clone()),
+        None => Err("property column index is out of bounds".into())
+    }
+}
+
+fn select_properties(properties: &ArrayNDProperties, index: &usize) -> Result<ValueProperties> {
+    let mut properties = properties.clone();
+    properties.c_stability = vec![take(&properties.c_stability, index)?];
+    properties.num_columns = Some(1);
+    if let Some(nature) = &properties.nature {
+        properties.nature = Some(match nature {
+            Nature::Continuous(continuous) => Nature::Continuous(NatureContinuous {
+                min: match &continuous.min {
+                    Vector1DNull::F64(min) => Vector1DNull::F64(vec![take(min, index)?]),
+                    Vector1DNull::I64(min) => Vector1DNull::I64(vec![take(min, index)?]),
+                    _ => return Err("min must be numeric".into())
+                },
+                max: match &continuous.max {
+                    Vector1DNull::F64(max) => Vector1DNull::F64(vec![take(max, index)?]),
+                    Vector1DNull::I64(max) => Vector1DNull::I64(vec![take(max, index)?]),
+                    _ => return Err("max must be numeric".into())
+                },
+            }),
+            Nature::Categorical(categorical) => Nature::Categorical(NatureCategorical {
+                categories: match &categorical.categories {
+                    Vector2DJagged::F64(cats) => Vector2DJagged::F64(vec![take(&cats, index)?]),
+                    Vector2DJagged::I64(cats) => Vector2DJagged::I64(vec![take(&cats, index)?]),
+                    Vector2DJagged::Bool(cats) => Vector2DJagged::Bool(vec![take(&cats, index)?]),
+                    Vector2DJagged::Str(cats) => Vector2DJagged::Str(vec![take(&cats, index)?]),
+                }
+            })
+        })
+    }
+    Ok(ValueProperties::ArrayND(properties))
+}
+
+fn get_common_value<T: Clone + Eq>(values: &Vec<T>) -> Option<T> {
+    match values.windows(2).all(|w| w[0] == w[1]) {
+        true => values.first().cloned(), false => None
+    }
+}
+
+fn stack_properties(all_properties: &Vec<ValueProperties>) -> Result<ValueProperties> {
+    let all_properties = all_properties.into_iter()
+        .map(|property| Ok(property.get_arraynd()?.clone()))
+        .collect::<Result<Vec<ArrayNDProperties>>>()?;
+
+    let num_records = get_common_value(&all_properties.iter()
+        .map(|prop| prop.num_records).collect()).unwrap_or(None);
+    let dataset_id = get_common_value(&all_properties.iter()
+        .map(|prop| prop.dataset_id).collect()).unwrap_or(None);
+
+    if num_records.is_none() && dataset_id.is_none() {
+        return Err("dataset may not be conformable".into())
+    }
+
+    if all_properties.iter().any(|prop| prop.aggregator.is_some()) {
+        return Err("indexing is not currently supported on aggregated data".into())
+    }
+
+    // TODO: preserve nature when indexing
+
+    Ok(ValueProperties::ArrayND(ArrayNDProperties {
+        num_records,
+        num_columns: all_properties.iter()
+            .map(|prop| prop.num_columns)
+            .fold(Some(0), |total, num| match (total, num) {
+                (Some(total), Some(num)) => Some(total + num),
+                _ => None
+            }),
+        nullity: get_common_value(&all_properties.iter().map(|prop| prop.nullity).collect()).unwrap_or(true),
+        releasable: get_common_value(&all_properties.iter().map(|prop| prop.releasable).collect()).unwrap_or(true),
+        c_stability: all_properties.iter().flat_map(|prop| prop.c_stability.clone()).collect(),
+        aggregator: None,
+        nature: None,
+        data_type: get_common_value(&all_properties.iter().map(|prop| prop.data_type.clone()).collect())
+            .ok_or::<Error>("dataset must have homogeneous type".into())?,
+        dataset_id
+    }))
 }

--- a/validator-rust/src/components/materialize.rs
+++ b/validator-rust/src/components/materialize.rs
@@ -6,6 +6,7 @@ use crate::{proto, base};
 
 use crate::components::{Component};
 use crate::base::{Hashmap, Value, NodeProperties, ValueProperties, HashmapProperties, ArrayNDProperties, DataType};
+use crate::utilities::serial::parse_i64_null;
 
 impl Component for proto::Materialize {
     // modify min, max, n, categories, is_public, non-null, etc. based on the arguments and component
@@ -35,6 +36,7 @@ impl Component for proto::Materialize {
                         aggregator: None,
                         nature: None,
                         data_type: DataType::Str,
+                        dataset_id: self.dataset_id.as_ref().and_then(parse_i64_null)
                     }))).collect()),
                 (None, Some(num_columns)) => Hashmap::<ValueProperties>::I64((0..num_columns)
                     .map(|name| (name.clone(), ValueProperties::ArrayND(ArrayNDProperties {
@@ -46,6 +48,7 @@ impl Component for proto::Materialize {
                         aggregator: None,
                         nature: None,
                         data_type: DataType::Str,
+                        dataset_id: self.dataset_id.as_ref().and_then(parse_i64_null)
                     }))).collect()),
                 _ => return Err("either column_names or num_columns must be specified".into())
             }

--- a/validator-rust/src/components/mean.rs
+++ b/validator-rust/src/components/mean.rs
@@ -45,28 +45,31 @@ impl Aggregator for proto::Mean {
         properties: &NodeProperties,
         sensitivity_type: &Sensitivity
     ) -> Result<Vec<f64>> {
-        let data_property = properties.get("data")
-            .ok_or("data: missing")?.get_arraynd()
-            .map_err(prepend("data:"))?.clone();
-
-        data_property.assert_is_not_aggregated()?;
-        data_property.assert_non_null()?;
 
         match sensitivity_type {
             Sensitivity::KNorm(k) => {
-                if k != &1 {
-                    return Err("Mean sensitivity is only implemented for KNorm of 1".into())
-                }
-                let min = data_property.get_min_f64()?;
-                let max = data_property.get_max_f64()?;
-                let num_records = data_property.get_num_records()? as f64;
 
-                Ok(min.iter()
-                    .zip(max)
-                    .map(|(min, max)| (max - min) / num_records)
-                    .collect())
+                let data_property = properties.get("data")
+                    .ok_or("data: missing")?.get_arraynd()
+                    .map_err(prepend("data:"))?.clone();
+
+                data_property.assert_non_null()?;
+                data_property.assert_is_not_aggregated()?;
+                let data_min = data_property.get_min_f64()?;
+                let data_max = data_property.get_max_f64()?;
+                let data_n = data_property.get_num_records()? as f64;
+
+                // AddRemove vs. Substitute share the same bounds
+
+                match k {
+                    1 | 2 => Ok(data_min.iter()
+                        .zip(data_max.iter())
+                        .map(|(min, max)| ((max - min) / data_n).powi(*k as i32))
+                        .collect()),
+                    _ => Err("KNorm sensitivity is only supported in L1 and L2 spaces".into())
+                }
             },
-            _ => return Err("Mean sensitivity is only implemented for KNorm of 1".into())
+            _ => Err("Mean sensitivity is only implemented for KNorm".into())
         }
     }
 }

--- a/validator-rust/src/components/mod.rs
+++ b/validator-rust/src/components/mod.rs
@@ -28,13 +28,14 @@ mod dp_moment_raw;
 mod dp_sum;
 mod filter;
 mod impute;
-mod index;
+pub mod index;
 mod kth_raw_sample_moment;
 mod maximum;
 mod materialize;
 mod minimum;
 mod partition;
 mod quantile;
+mod reshape;
 mod mean;
 mod mechanism_exponential;
 mod mechanism_gaussian;
@@ -211,7 +212,7 @@ impl Component for proto::component::Variant {
 
             ExponentialMechanism, GaussianMechanism, LaplaceMechanism, SimpleGeometricMechanism,
 
-            Minimum, Quantile, Resize, Sum, Variance,
+            Minimum, Quantile, Reshape, Resize, Sum, Variance,
 
             Add, Subtract, Divide, Multiply, Power, Log, Modulo, LogicalAnd, LogicalOr, Negate,
             Equal, LessThan, GreaterThan, Negative

--- a/validator-rust/src/components/reshape.rs
+++ b/validator-rust/src/components/reshape.rs
@@ -1,0 +1,56 @@
+use crate::errors::*;
+
+use crate::components::Component;
+use std::collections::HashMap;
+use crate::base::{Value, prepend, ValueProperties};
+use crate::base;
+use crate::proto;
+
+impl Component for proto::Reshape {
+    fn propagate_property(
+        &self,
+        _privacy_definition: &proto::PrivacyDefinition,
+        _public_arguments: &HashMap<String, Value>,
+        properties: &base::NodeProperties,
+    ) -> Result<ValueProperties> {
+        let mut data_property = properties.get("data")
+            .ok_or("data: missing")?.get_arraynd()
+            .map_err(prepend("data:"))?.clone();
+
+        if !data_property.releasable {
+            return Err("data must be public/releasable to reshape".into())
+        }
+
+        data_property.num_records = match self.shape.len().clone() {
+            0 => Some(1),
+            1 | 2 => Some(self.shape[0] as i64),
+            _ => return Err("dimensionality may not be greater than 2".into())
+        };
+
+        data_property.num_columns = match self.shape.len().clone() {
+            0 | 1 => Some(1),
+            2 => Some(self.shape[1] as i64),
+            _ => return Err("dimensionality may not be greater than 2".into())
+        };
+
+        if data_property.num_records.unwrap() < 1 {
+            return Err("number of records must be greater than zero".into())
+        }
+        if data_property.num_columns.unwrap() < 1 {
+            return Err("number of columns must be greater than zero".into())
+        }
+
+        // Treat this as a new dataset, because number of rows is not necessarily the same anymore
+        // This exists to prevent binary ops on non-conformable arrays from being approved
+        data_property.dataset_id = None;
+
+        Ok(data_property.into())
+    }
+
+    fn get_names(
+        &self,
+        _properties: &base::NodeProperties,
+    ) -> Result<Vec<String>> {
+        Err("get_names not implemented".into())
+    }
+}

--- a/validator-rust/src/components/transforms.rs
+++ b/validator-rust/src/components/transforms.rs
@@ -40,9 +40,10 @@ impl Component for proto::Add {
                 .zip(broadcast(&right_property.c_stability, &num_columns)?)
                 .map(|(l, r)| l.max(r)).collect(),
             num_columns: Some(num_columns),
-            num_records: Some(num_records),
+            num_records,
             aggregator: None,
-            data_type: left_property.data_type
+            data_type: left_property.data_type,
+            dataset_id: left_property.dataset_id
         }.into())
     }
 
@@ -83,9 +84,10 @@ impl Component for proto::Subtract {
                 .zip(broadcast(&right_property.c_stability, &num_columns)?)
                 .map(|(l, r)| l.max(r)).collect(),
             num_columns: Some(num_columns),
-            num_records: Some(num_records),
+            num_records,
             aggregator: None,
-            data_type: left_property.data_type
+            data_type: left_property.data_type,
+            dataset_id: left_property.dataset_id
         }.into())
     }
 
@@ -153,9 +155,10 @@ impl Component for proto::Divide {
                 .zip(broadcast(&right_property.c_stability, &num_columns)?)
                 .map(|(l, r)| l.max(r)).collect(),
             num_columns: Some(num_columns),
-            num_records: Some(num_records),
+            num_records,
             aggregator: None,
-           data_type: left_property.data_type
+           data_type: left_property.data_type,
+            dataset_id: left_property.dataset_id
         }.into())
     }
 
@@ -197,8 +200,9 @@ impl Component for proto::Multiply {
                 .map(|(l, r)| l.max(r)).collect(),
             num_columns: Some(num_columns),
             data_type: left_property.data_type,
-           num_records: Some(num_records),
-            aggregator: None
+           num_records,
+            aggregator: None,
+            dataset_id: left_property.dataset_id
         }.into())
     }
 
@@ -236,9 +240,10 @@ impl Component for proto::Power {
                 .zip(broadcast(&right_property.c_stability, &num_columns)?)
                 .map(|(l, r)| l.max(r)).collect(),
             num_columns: Some(num_columns),
-            num_records: Some(num_records),
+            num_records,
             data_type: left_property.data_type,
-            aggregator: None
+            aggregator: None,
+            dataset_id: left_property.dataset_id
         }.into())
     }
 
@@ -279,9 +284,10 @@ impl Component for proto::Log {
                 .zip(broadcast(&right_property.c_stability, &num_columns)?)
                 .map(|(l, r)| l.max(r)).collect(),
             num_columns: Some(num_columns),
-            num_records: Some(num_records),
+            num_records,
             data_type: left_property.data_type,
             aggregator: None,
+            dataset_id: left_property.dataset_id
         }.into())
     }
 
@@ -370,9 +376,10 @@ impl Component for proto::Modulo {
                 .zip(broadcast(&right_property.c_stability, &num_columns)?)
                 .map(|(l, r)| l.max(r)).collect(),
             num_columns: Some(num_columns),
-            num_records: Some(num_records),
+            num_records,
             data_type: left_property.data_type,
-            aggregator: None
+            aggregator: None,
+            dataset_id: left_property.dataset_id
         }.into())
     }
     fn get_names(
@@ -459,9 +466,10 @@ impl Component for proto::And {
                 .zip(broadcast(&right_property.c_stability, &num_columns)?)
                 .map(|(l, r)| l.max(r)).collect(),
             num_columns: Some(num_columns),
-            num_records: Some(num_records),
+            num_records,
             aggregator: None,
-            data_type: left_property.data_type
+            data_type: left_property.data_type,
+            dataset_id: left_property.dataset_id
         }.into())
     }
 
@@ -500,9 +508,10 @@ impl Component for proto::Or {
                 .zip(broadcast(&right_property.c_stability, &num_columns)?)
                 .map(|(l, r)| l.max(r)).collect(),
             num_columns: Some(num_columns),
-            num_records: Some(num_records),
+            num_records,
             aggregator: None,
-            data_type: left_property.data_type
+            data_type: left_property.data_type,
+            dataset_id: left_property.dataset_id
         }.into())
     }
 
@@ -541,9 +550,10 @@ impl Component for proto::Negate {
                 .zip(broadcast(&right_property.c_stability, &num_columns)?)
                 .map(|(l, r)| l.max(r)).collect(),
             num_columns: Some(num_columns),
-            num_records: Some(num_records),
+            num_records,
             aggregator: None,
-            data_type: left_property.data_type
+            data_type: left_property.data_type,
+            dataset_id: left_property.dataset_id
         }.into())
     }
 
@@ -582,9 +592,10 @@ impl Component for proto::Equal {
                 .zip(broadcast(&right_property.c_stability, &num_columns)?)
                 .map(|(l, r)| l.max(r)).collect(),
             num_columns: Some(num_columns),
-            num_records: Some(num_records),
+            num_records,
             aggregator: None,
-            data_type: left_property.data_type
+            data_type: left_property.data_type,
+            dataset_id: left_property.dataset_id
         }.into())
     }
 
@@ -623,9 +634,10 @@ impl Component for proto::LessThan {
                 .zip(broadcast(&right_property.c_stability, &num_columns)?)
                 .map(|(l, r)| l.max(r)).collect(),
             num_columns: Some(num_columns),
-            num_records: Some(num_records),
+            num_records,
             aggregator: None,
-            data_type: left_property.data_type
+            data_type: left_property.data_type,
+            dataset_id: left_property.dataset_id
         }.into())
     }
 
@@ -664,9 +676,10 @@ impl Component for proto::GreaterThan {
                 .zip(broadcast(&right_property.c_stability, &num_columns)?)
                 .map(|(l, r)| l.max(r)).collect(),
             num_columns: Some(num_columns),
-            num_records: Some(num_records),
+            num_records,
             aggregator: None,
-            data_type: left_property.data_type
+            data_type: left_property.data_type,
+            dataset_id: left_property.dataset_id
         }.into())
     }
 
@@ -685,7 +698,7 @@ pub struct Operators {
     pub bool: Option<Box<dyn Fn(&bool, &bool) -> bool>>,
 }
 
-pub fn propagate_binary_shape(left_property: &ArrayNDProperties, right_property: &ArrayNDProperties) -> Result<(i64, i64)> {
+pub fn propagate_binary_shape(left_property: &ArrayNDProperties, right_property: &ArrayNDProperties) -> Result<(i64, Option<i64>)> {
 
     let left_num_columns = left_property.get_num_columns()?;
     let right_num_columns = right_property.get_num_columns()?;
@@ -707,13 +720,16 @@ pub fn propagate_binary_shape(left_property: &ArrayNDProperties, right_property:
     let right_is_row_broadcastable = right_property.releasable && right_num_records == 1;
 
     if !(left_is_row_broadcastable || right_is_row_broadcastable) && !(left_num_records == right_num_records) {
+        if left_property.dataset_id == right_property.dataset_id {
+            return Ok((output_num_columns, None))
+        }
         return Err("number of rows must be the same for left and right arguments".into());
     }
 
     // either left, right or both are broadcastable, so take the largest
     let output_num_records = left_num_records.max(right_num_records);
 
-    Ok((output_num_columns, output_num_records))
+    Ok((output_num_columns, Some(output_num_records)))
 }
 
 pub fn propagate_binary_nature(left_property: &ArrayNDProperties, right_property: &ArrayNDProperties, operator: &Operators, &output_num_columns: &i64) -> Result<Option<Nature>> {

--- a/validator-rust/src/components/variance.rs
+++ b/validator-rust/src/components/variance.rs
@@ -44,31 +44,44 @@ impl Component for proto::Variance {
 impl Aggregator for proto::Variance {
     fn compute_sensitivity(
         &self,
-        _privacy_definition: &proto::PrivacyDefinition,
+        privacy_definition: &proto::PrivacyDefinition,
         properties: &NodeProperties,
         sensitivity_type: &Sensitivity
     ) -> Result<Vec<f64>> {
-        let data_property = properties.get("data")
-            .ok_or("data: missing")?.get_arraynd()
-            .map_err(prepend("data:"))?.clone();
-
-        data_property.assert_non_null()?;
 
         match sensitivity_type {
             Sensitivity::KNorm(k) => {
-                if k != &1 {
-                    return Err("Variance sensitivity is only implemented for KNorm of 1".into());
-                }
-                let min = data_property.get_min_f64()?;
-                let max = data_property.get_max_f64()?;
-                let num_records = data_property.get_num_records()? as f64;
 
-                Ok(min.iter()
-                    .zip(max)
-                    .map(|(min, max)| (max - min).powi(2) / num_records)
+                let data_property = properties.get("data")
+                    .ok_or("data: missing")?.get_arraynd()
+                    .map_err(prepend("data:"))?.clone();
+
+                data_property.assert_non_null()?;
+                data_property.assert_is_not_aggregated()?;
+                let data_min = data_property.get_min_f64()?;
+                let data_max = data_property.get_max_f64()?;
+                let data_n = data_property.get_num_records()? as f64;
+
+                let delta_degrees_of_freedom = if self.finite_sample_correction { 1 } else { 0 } as f64;
+                let normalization = data_n - delta_degrees_of_freedom;
+
+                use proto::privacy_definition::Neighboring;
+                let neighboring_type = Neighboring::from_i32(privacy_definition.neighboring)
+                    .ok_or::<Error>("neighboring definition must be either \"AddRemove\" or \"Substitute\"".into())?;
+
+                let scaling_constant: f64 = match k {
+                    1 | 2 => match neighboring_type {
+                        Neighboring::AddRemove => data_n / (data_n + 1.) / normalization,
+                        Neighboring::Substitute => (data_n - 1.) / data_n / normalization
+                    },
+                    _ => return Err("KNorm sensitivity is only supported in L1 and L2 spaces".into())
+                };
+
+                Ok(data_min.iter().zip(data_max.iter())
+                    .map(|(min, max)| ((max - min).powi(2) * scaling_constant).powi(*k as i32))
                     .collect())
             },
-            _ => return Err("Variance sensitivity is only implemented for KNorm of 1".into())
+            _ => Err("Variance sensitivity is only implemented for KNorm of 1".into())
         }
     }
 }

--- a/validator-rust/src/utilities/inference.rs
+++ b/validator-rust/src/utilities/inference.rs
@@ -350,7 +350,8 @@ pub fn infer_property(value: &Value) -> Result<ValueProperties> {
                 ArrayND::F64(_) => DataType::F64,
                 ArrayND::I64(_) => DataType::I64,
                 ArrayND::Str(_) => DataType::Str,
-            }
+            },
+            dataset_id: None
         }.into(),
         Value::Hashmap(hashmap) => HashmapProperties {
             num_records: None,

--- a/validator-rust/src/utilities/json.rs
+++ b/validator-rust/src/utilities/json.rs
@@ -83,10 +83,9 @@ pub fn arraynd_to_json<T: Serialize + Clone>(array: &ArrayD<T>) -> Result<serde_
     match array.ndim() {
         0 => Ok(serde_json::json!(array.first().unwrap())),
         1 => Ok(serde_json::json!(array.clone().into_dimensionality::<Ix1>().unwrap().to_vec())),
-//        2 => {
-//            serde_json::json!(array.into_dimensionality::<Ix2>().clone().unwrap().to_vec())
-//        },
-        _ => Err("converting a matrix to json is not implemented".into())
+        // TODO: preserve shape
+        2 => Ok(serde_json::json!(array.iter().cloned().collect::<Vec<T>>())),
+        _ => Err("array must have dimensionality less than 2".into())
     }
 }
 

--- a/validator-rust/src/utilities/serial.rs
+++ b/validator-rust/src/utilities/serial.rs
@@ -254,7 +254,8 @@ pub fn parse_arraynd_properties(value: &proto::ArrayNdProperties) -> ArrayNDProp
             },
             None => None,
         },
-        data_type: parse_data_type(&proto::DataType::from_i32(value.data_type).unwrap())
+        data_type: parse_data_type(&proto::DataType::from_i32(value.data_type).unwrap()),
+        dataset_id: value.dataset_id.as_ref().and_then(parse_i64_null)
     }
 }
 
@@ -556,7 +557,8 @@ pub fn serialize_arraynd_properties(value: &ArrayNDProperties) -> proto::ArrayNd
             }),
             None => None
         },
-        data_type: serialize_data_type(&value.data_type) as i32
+        data_type: serialize_data_type(&value.data_type) as i32,
+        dataset_id: Some(serialize_i64_null(&value.dataset_id))
     }
 }
 


### PR DESCRIPTION
- Finished implementing the Index component, allowing multicolumnar data throughout the library.
- Cleaned up mechanism implementations in runtime to use a privacy usage broadcasting function. 
- Finished implementing covariance/cross-covariance.
- Finished implementing finite sample corrections.
- Implemented the sensitivities from the Sensitivity calcs pull request (covariance, variance, sum, mean, count) * (L1, L2) * (Add/Remove, Substitute)
- Added Reshape component. Used for unflattening upper triangular and dense matrices.

Misc:
- Fixed a memory corruption bug with stacking. I had previously pulled and tweaked/unknowingly broke a function with an unsafe array allocation from NDArray to get around the Copy trait requirement in stack (String does not have Copy, and empty String arrays cannot be safely allocated without Copy).
- Count always emits a scalar
- Index on ArrayNDs is supported from bindings
- Track original dataset, to pass conformability check of arrays for binary ops and Index, without knowing N.
- Removed unwraps from report generation/general cleanup
- Re-added unwraps to utilities where errors are impossible (sorry for the flip-flop Christian)