### PR TITLE
issue #149, license value required for crate.io publication

### DIFF
--- a/runtime-rust/Cargo.toml
+++ b/runtime-rust/Cargo.toml
@@ -8,6 +8,7 @@ keywords = ["differential privacy", "data privacy"]
 categories = ["cryptography", "science"] # up to 5 allowed, must match those listed at https://crates.io/category_slugs
 repository = "https://github.com/opendifferentialprivacy/whitenoise-core"
 edition = "2018"
+license = "MIT"
 
 [dependencies]
 prost = "0.5.0"


### PR DESCRIPTION
license value must be in both validator-rust and runtime-rust