### PR TITLE
correct link in the components list doc

### DIFF
--- a/validator-rust/Cargo.toml
+++ b/validator-rust/Cargo.toml
@@ -27,6 +27,7 @@ serde = "1.0.104"
 noisy_float = "0.1.12"
 statrs = "0.12.0"
 libmath = "0.2.1"
+heck = "0.3.1"
 
 [build-dependencies]
 serde_json = "1.0.48"
@@ -34,6 +35,7 @@ serde = "1.0.104"
 prost-build = { version = "0.5.0" }
 cbindgen = "0.9.1"
 build-deps = "0.1.4"
+heck = "0.3.1"
 
 [lib]
 name = "whitenoise_validator"

--- a/validator-rust/Cargo.toml
+++ b/validator-rust/Cargo.toml
@@ -27,7 +27,6 @@ serde = "1.0.104"
 noisy_float = "0.1.12"
 statrs = "0.12.0"
 libmath = "0.2.1"
-heck = "0.3.1"
 
 [build-dependencies]
 serde_json = "1.0.48"

--- a/validator-rust/build.rs
+++ b/validator-rust/build.rs
@@ -1,5 +1,7 @@
 extern crate prost_build;
 //extern crate cbindgen;
+extern crate heck;
+use self::heck::CamelCase;
 
 use std::io;
 use std::path::Path;
@@ -134,7 +136,7 @@ message Component {
     "#.to_string();
 
     let proto_text_variants = components.iter().enumerate()
-        .map(|(id, component)| format!("        {} {} = {};", component.id, component.name, id + 100))
+        .map(|(id, component)| format!("        {} {} = {};", component.id.to_camel_case(), component.name.to_camel_case(), id + 100))
         .collect::<Vec<String>>().join("\n");
 
     let proto_text_messages = components.iter()
@@ -145,11 +147,11 @@ message Component {
                 format!("{}\n    {} {} = {};",
                         doc(&spec.description, "    "),
                         spec.arg_type.clone().unwrap(),
-                        name,
+                        name.to_camel_case(),
                         id + 1)
             }).collect::<Vec<String>>().join("\n");
 
-            let mut component_description = format!("{} Component", component.id);
+            let mut component_description = format!("{} Component", component.id.to_camel_case());
             if let Some(description) = component.description.clone() {
                 component_description.push_str(&format!("\n\n{}", description));
             }
@@ -176,7 +178,7 @@ message Component {
             format!("{}\nmessage {} {{\n{}\n}}",
                     // code gen for the header
                     text_component_header,
-                    component.id,
+                    component.id.to_camel_case(),
                     text_options)
         })
         .collect::<Vec<String>>().join("\n\n");
@@ -218,7 +220,7 @@ message Component {
                 .collect::<Vec<String>>().join(", ");
 
             format!("/// | [{}](../../proto/struct.{}.html) | {} | {} |  ",
-                    component.id, component.id, component.name, inputs)
+                    component.id.to_camel_case(), component.id.to_camel_case(), component.name.to_camel_case(), inputs)
         })
         .collect::<Vec<String>>().join("\n");
 

--- a/validator-rust/build.rs
+++ b/validator-rust/build.rs
@@ -136,7 +136,7 @@ message Component {
     "#.to_string();
 
     let proto_text_variants = components.iter().enumerate()
-        .map(|(id, component)| format!("        {} {} = {};", component.id.to_camel_case(), component.name.to_camel_case(), id + 100))
+        .map(|(id, component)| format!("        {} {} = {};", component.id, component.name, id + 100))
         .collect::<Vec<String>>().join("\n");
 
     let proto_text_messages = components.iter()
@@ -147,11 +147,11 @@ message Component {
                 format!("{}\n    {} {} = {};",
                         doc(&spec.description, "    "),
                         spec.arg_type.clone().unwrap(),
-                        name.to_camel_case(),
+                        name,
                         id + 1)
             }).collect::<Vec<String>>().join("\n");
 
-            let mut component_description = format!("{} Component", component.id.to_camel_case());
+            let mut component_description = format!("{} Component", component.id);
             if let Some(description) = component.description.clone() {
                 component_description.push_str(&format!("\n\n{}", description));
             }
@@ -178,7 +178,7 @@ message Component {
             format!("{}\nmessage {} {{\n{}\n}}",
                     // code gen for the header
                     text_component_header,
-                    component.id.to_camel_case(),
+                    component.id,
                     text_options)
         })
         .collect::<Vec<String>>().join("\n\n");
@@ -220,7 +220,7 @@ message Component {
                 .collect::<Vec<String>>().join(", ");
 
             format!("/// | [{}](../../proto/struct.{}.html) | {} | {} |  ",
-                    component.id.to_camel_case(), component.id.to_camel_case(), component.name.to_camel_case(), inputs)
+                    component.id, component.id.to_camel_case(), component.name, inputs)
         })
         .collect::<Vec<String>>().join("\n");
 


### PR DESCRIPTION
- Minor change to correct link in the components list
   - e.g. `struct.DPMean.html` was used in link to `struct.DpMean.html`, now case is consistent