### PR TITLE
when privacy checks fail, mark as not releasable

### DIFF
--- a/validator-rust/src/components/mechanism_exponential.rs
+++ b/validator-rust/src/components/mechanism_exponential.rs
@@ -33,20 +33,26 @@ impl Component for proto::ExponentialMechanism {
             &SensitivitySpace::Exponential)?;
 
         let sensitivities = sensitivity_values.array()?.f64()?;
-        let usages = broadcast_privacy_usage(&self.privacy_usage, sensitivities.len())?;
-        let epsilons = usages.iter().map(get_epsilon).collect::<Result<Vec<f64>>>()?;
 
-        // epsilons must be greater than 0.
-        for epsilon in epsilons.into_iter(){
-            if epsilon <= 0.0 {
-                return Err("epsilon: privacy parameter epsilon must be greater than 0".into());
-            };
-            if epsilon > 1.0   {
-                println!("Warning: A large privacy parameter of epsilon = {} is in use", epsilon.to_string());
+
+        if self.privacy_usage.len() == 0 {
+            data_property.releasable = false;
+        } else {
+            let usages = broadcast_privacy_usage(&self.privacy_usage, sensitivities.len())?;
+            let epsilons = usages.iter().map(get_epsilon).collect::<Result<Vec<f64>>>()?;
+
+            // epsilons must be greater than 0.
+            for epsilon in epsilons.into_iter() {
+                if epsilon <= 0.0 {
+                    return Err("epsilon: privacy parameter epsilon must be greater than 0".into());
+                };
+                if epsilon > 1.0 {
+                    println!("Warning: A large privacy parameter of epsilon = {} is in use", epsilon.to_string());
+                }
             }
+            data_property.releasable = true;
         }
 
-        data_property.releasable = true;
         Ok(data_property.into())
     }
 }

--- a/validator-rust/src/components/mechanism_laplace.rs
+++ b/validator-rust/src/components/mechanism_laplace.rs
@@ -37,21 +37,27 @@ impl Component for proto::LaplaceMechanism {
             &SensitivitySpace::KNorm(1))?;
 
         let sensitivities = sensitivity_values.array()?.f64()?;
-        let usages = broadcast_privacy_usage(&self.privacy_usage, sensitivities.len())?;
-        let epsilons = usages.iter().map(get_epsilon).collect::<Result<Vec<f64>>>()?;
 
-        // epsilons must be greater than 0.
-        for epsilon in epsilons.into_iter(){
-            if epsilon <= 0.0 {
-                return Err("epsilon: privacy parameter epsilon must be greater than 0".into());
-            };
-            if epsilon > 1.0   {
-                println!("Warning: A large privacy parameter of epsilon = {} is in use", epsilon.to_string());
+        if self.privacy_usage.len() == 0 {
+            data_property.releasable = false;
+        } else {
+            let usages = broadcast_privacy_usage(&self.privacy_usage, sensitivities.len())?;
+            let epsilons = usages.iter().map(get_epsilon).collect::<Result<Vec<f64>>>()?;
+
+            // epsilons must be greater than 0.
+            for epsilon in epsilons.into_iter(){
+                if epsilon <= 0.0 {
+                    return Err("epsilon: privacy parameter epsilon must be greater than 0".into());
+                };
+                if epsilon > 1.0   {
+                    println!("Warning: A large privacy parameter of epsilon = {} is in use", epsilon.to_string());
+                }
             }
+
+            data_property.releasable = true;
         }
 
         data_property.aggregator = None;
-        data_property.releasable = true;
 
         Ok(data_property.into())
     }

--- a/validator-rust/src/components/mechanism_simple_geometric.rs
+++ b/validator-rust/src/components/mechanism_simple_geometric.rs
@@ -36,21 +36,27 @@ impl Component for proto::SimpleGeometricMechanism {
             &SensitivitySpace::KNorm(1))?;
 
         let sensitivities = sensitivity_values.array()?.f64()?;
-        let usages = broadcast_privacy_usage(&self.privacy_usage, sensitivities.len())?;
-        let epsilons = usages.iter().map(get_epsilon).collect::<Result<Vec<f64>>>()?;
 
-        // epsilons must be greater than 0.
-        for epsilon in epsilons.into_iter(){
-            if epsilon <= 0.0 {
-                return Err("epsilon: privacy parameter epsilon must be greater than 0".into());
-            };
-            if epsilon > 1.0   {
-                println!("Warning: A large privacy parameter of epsilon = {} is in use", epsilon.to_string());
+
+        if self.privacy_usage.len() == 0 {
+            data_property.releasable = false;
+        } else {
+            let usages = broadcast_privacy_usage(&self.privacy_usage, sensitivities.len())?;
+            let epsilons = usages.iter().map(get_epsilon).collect::<Result<Vec<f64>>>()?;
+
+            // epsilons must be greater than 0.
+            for epsilon in epsilons.into_iter() {
+                if epsilon <= 0.0 {
+                    return Err("epsilon: privacy parameter epsilon must be greater than 0".into());
+                };
+                if epsilon > 1.0 {
+                    println!("Warning: A large privacy parameter of epsilon = {} is in use", epsilon.to_string());
+                }
             }
+            data_property.releasable = true;
         }
 
         data_property.aggregator = None;
-        data_property.releasable = true;
 
         Ok(data_property.into())
     }

--- a/validator-rust/src/utilities/mod.rs
+++ b/validator-rust/src/utilities/mod.rs
@@ -192,7 +192,7 @@ pub fn propagate_properties(
         let component_properties = match (dynamic, component_properties) {
             (_, Ok(properties)) => properties,
             (true, Err(err)) => {
-                failed_ids.insert(traversal.pop().unwrap());
+                failed_ids.insert(node_id);
                 warnings.push(serialize_error(err));
                 continue
             },


### PR DESCRIPTION
This fixes the `accuracy=` argument in bindings component constructors.