### PR TITLE
V0.2.1

### DIFF
--- a/ffi-rust/Cargo.toml
+++ b/ffi-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "whitenoise_ffi"
-version = "0.2.0"
+version = "0.2.1"
 authors = ["OpenDP-WhiteNoise <whitenoise@opendp.io>"]
 description = "A wrapper library for interfacing with the Whitenoise over ffi."
 readme = "README.md"
@@ -17,11 +17,11 @@ indexmap = "1.4.0"
 
 [dependencies.whitenoise_validator]
 path = "../validator-rust/"
-version = "0.2.0"
+version = "0.2.1"
 
 [dependencies.whitenoise_runtime]
 path = "../runtime-rust/"
-version = "0.2.0"
+version = "0.2.1"
 optional = true
 default-features = false
 

--- a/runtime-rust/Cargo.toml
+++ b/runtime-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "whitenoise_runtime"
-version = "0.2.0"
+version = "0.2.1"
 authors = ["OpenDP-WhiteNoise <whitenoise@opendp.io>"]
 description = "A library of algorithms for differentially private data analysis."
 readme = "README.md"
@@ -39,7 +39,7 @@ noisy_float = "0.1.12"
     optional = true
 
     [dependencies.whitenoise_validator]
-    version = "0.2.0"
+        version = "0.2.1"
     path = "../validator-rust/"
 
 [features]

--- a/runtime-rust/src/utilities/mechanisms.rs
+++ b/runtime-rust/src/utilities/mechanisms.rs
@@ -157,18 +157,16 @@ pub fn exponential_mechanism<T>(
 ) -> Result<T> where T: Clone, {
 
     // get vector of e^(util), then use to find probabilities
-    use rug::{float::Constant, Float, ops::Pow};
-
-    // establish rug versions of values
-    let rug_e = Float::with_val(53, Constant::Euler);
-    let rug_eps = Float::with_val(53, epsilon);
-    let rug_sens = Float::with_val(53, sensitivity);
+    macro_rules! to_rug {($v:expr) => {rug::Float::with_val(53, $v)}}
 
     // establish selection probabilities for each element
-    let e_util_vec: Vec<rug::Float> = utilities.iter()
-        .map(|x| rug_e.clone().pow(rug_eps.clone() * Float::with_val(53, x) / (2.0 * rug_sens.clone()))).collect();
-    let sum_e_util_vec: rug::Float = Float::with_val(53, Float::sum(e_util_vec.iter()));
-    let probability_vec: Vec<whitenoise_validator::Float> = e_util_vec.iter().map(|x| (x / sum_e_util_vec.clone()).to_f64() as whitenoise_validator::Float).collect();
+    let e_util_vec: Vec<rug::Float> = utilities.into_iter()
+        .map(|util| to_rug!(to_rug!(epsilon) * to_rug!(util) / (2. * to_rug!(sensitivity))).exp())
+        .collect();
+    let sum_e_util_vec = to_rug!(rug::Float::sum(e_util_vec.iter()));
+    let probability_vec: Vec<Float> = e_util_vec.into_iter()
+        .map(|x| (x / sum_e_util_vec.clone()).to_f64() as Float)
+        .collect();
 
     // sample element relative to probability
     utilities::sample_from_set(candidate_set, &probability_vec, enforce_constant_time)

--- a/runtime-rust/src/utilities/mechanisms.rs
+++ b/runtime-rust/src/utilities/mechanisms.rs
@@ -2,6 +2,7 @@ use whitenoise_validator::errors::*;
 
 use crate::utilities::noise;
 use crate::utilities;
+use whitenoise_validator::Float;
 
 /// Returns noise drawn according to the Laplace mechanism
 ///

--- a/scripts/update_version.toml
+++ b/scripts/update_version.toml
@@ -1,0 +1,11 @@
+[version]
+# version to update to
+major = 0
+minor = 2
+patch = 1
+
+[paths]
+# locations of repositories to update
+core = "/Users/michael/whitenoise/python/whitenoise-core"
+python = "/Users/michael/whitenoise/python"
+R = "/Users/michael/whitenoise/R"

--- a/validator-rust/Cargo.toml
+++ b/validator-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "whitenoise_validator"
-version = "0.2.0"
+version = "0.2.1"
 authors = ["OpenDP-WhiteNoise <whitenoise@opendp.io>"]
 description = "A library for validating whether or not an analysis is differentially private."
 readme = "README.md"

--- a/validator-rust/prototypes/base.proto
+++ b/validator-rust/prototypes/base.proto
@@ -137,6 +137,8 @@ message ArrayProperties {
         /// categories of each column
         NatureCategorical categorical = 101;
     }
+
+    bool naturally_ordered = 12;
 }
 
 message NatureContinuous {

--- a/validator-rust/prototypes/components/SimpleGeometricMechanism.json
+++ b/validator-rust/prototypes/components/SimpleGeometricMechanism.json
@@ -5,10 +5,12 @@
       "description": "Result to be released privately via the Geometric mechanism."
     },
     "lower": {
-      "type_value": "Array"
+      "type_value": "Array",
+      "default_python": "None"
     },
     "upper": {
-      "type_value": "Array"
+      "type_value": "Array",
+      "default_python": "None"
     }
   },
   "id": "SimpleGeometricMechanism",

--- a/validator-rust/prototypes/components/SimpleGeometricMechanism.json
+++ b/validator-rust/prototypes/components/SimpleGeometricMechanism.json
@@ -6,11 +6,13 @@
     },
     "lower": {
       "type_value": "Array",
-      "default_python": "None"
+      "default_python": "None",
+      "description": "Lower bound of the statistic to be privatized."
     },
     "upper": {
       "type_value": "Array",
-      "default_python": "None"
+      "default_python": "None",
+      "description": "Upper bound of the statistic to be privatized."
     }
   },
   "id": "SimpleGeometricMechanism",

--- a/validator-rust/src/base.rs
+++ b/validator-rust/src/base.rs
@@ -696,7 +696,9 @@ pub struct ArrayProperties {
     /// number of axes in the array
     pub dimensionality: Option<i64>,
     /// used for tracking subpartitions
-    pub group_id: Vec<GroupId>
+    pub group_id: Vec<GroupId>,
+    /// used to determine if order of rows has changed
+    pub naturally_ordered: bool
 }
 
 

--- a/validator-rust/src/base.rs
+++ b/validator-rust/src/base.rs
@@ -734,7 +734,9 @@ impl ArrayProperties {
             Some(value) => match value {
                 Nature::Continuous(continuous) => match continuous.lower {
                     Vector1DNull::Float(bound) => Ok(bound),
-                    _ => Err("lower must be composed of floats".into())
+                    Vector1DNull::Int(bound) => Ok(bound.into_iter()
+                        .map(|v_opt| v_opt.map(|v| v as Float)).collect()),
+                    _ => Err("lower must be numeric".into())
                 },
                 _ => Err("lower must be an array".into())
             },
@@ -751,7 +753,9 @@ impl ArrayProperties {
             Some(value) => match value {
                 Nature::Continuous(continuous) => match continuous.upper {
                     Vector1DNull::Float(bound) => Ok(bound),
-                    _ => Err("upper must be composed of floats".into())
+                    Vector1DNull::Int(bound) => Ok(bound.into_iter()
+                        .map(|v_opt| v_opt.map(|v| v as Float)).collect()),
+                    _ => Err("upper must be numeric".into())
                 },
                 _ => Err("upper must be an array".into())
             },

--- a/validator-rust/src/components/exponential_mechanism.rs
+++ b/validator-rust/src/components/exponential_mechanism.rs
@@ -72,7 +72,8 @@ impl Component for proto::ExponentialMechanism {
             // TODO: preserve dimensionality through exponential mechanism
             //     All outputs become 2D, so 1D outputs are lost
             dimensionality: Some(2),
-            group_id: vec![]
+            group_id: vec![],
+            naturally_ordered: true
         };
 
         let privacy_usage = self.privacy_usage.iter().cloned().map(Ok)

--- a/validator-rust/src/components/literal.rs
+++ b/validator-rust/src/components/literal.rs
@@ -28,7 +28,8 @@ impl Component for proto::Literal {
             // this is a library-wide assumption - that datasets initially have more than zero rows
             is_not_empty: true,
             dimensionality: None,
-            group_id: vec![]
+            group_id: vec![],
+            naturally_ordered: true
         }).into())
     }
 }

--- a/validator-rust/src/components/materialize.rs
+++ b/validator-rust/src/components/materialize.rs
@@ -32,7 +32,8 @@ impl Component for proto::Materialize {
                     // this is a library-wide assumption - that datasets initially have more than zero rows
                     is_not_empty: true,
                     dimensionality: Some(1),
-                    group_id: vec![]
+                    group_id: vec![],
+                    naturally_ordered: true
                 }))).collect(),
         }).into())
     }

--- a/validator-rust/src/components/simple_geometric_mechanism.rs
+++ b/validator-rust/src/components/simple_geometric_mechanism.rs
@@ -5,10 +5,12 @@ use crate::{proto, base, Warnable};
 
 use crate::components::{Component, Expandable};
 use crate::base::{Value, SensitivitySpace, ValueProperties, DataType, NodeProperties, IndexKey};
-use crate::utilities::{prepend, expand_mechanism};
+use crate::utilities::{prepend, expand_mechanism, get_literal};
 use crate::utilities::privacy::{spread_privacy_usage, get_epsilon, privacy_usage_check};
 use itertools::Itertools;
 use indexmap::map::IndexMap;
+use crate::utilities::inference::infer_property;
+use ndarray::arr1;
 
 
 impl Component for proto::SimpleGeometricMechanism {
@@ -25,18 +27,6 @@ impl Component for proto::SimpleGeometricMechanism {
 
         if privacy_definition.group_size == 0 {
             return Err("group size must be greater than zero".into())
-        }
-
-        if properties.get::<IndexKey>(&"lower".into())
-            .ok_or("lower: missing")?.array()
-            .map_err(prepend("lower:"))?.data_type != DataType::Int {
-            return Err("lower: must be of integer atomic type".into());
-        }
-
-        if properties.get::<IndexKey>(&"upper".into())
-            .ok_or("upper: missing")?.array()
-            .map_err(prepend("upper:"))?.data_type != DataType::Int {
-            return Err("upper: must be of integer atomic type".into());
         }
 
         let mut data_property = properties.get::<IndexKey>(&"data".into())
@@ -77,12 +67,26 @@ impl Expandable for proto::SimpleGeometricMechanism {
         &self,
         privacy_definition: &Option<proto::PrivacyDefinition>,
         component: &proto::Component,
-        _public_arguments: &IndexMap<IndexKey, &Value>,
+        public_arguments: &IndexMap<IndexKey, &Value>,
         properties: &base::NodeProperties,
         component_id: u32,
-        maximum_id: u32,
+        mut maximum_id: u32,
     ) -> Result<base::ComponentExpansion> {
-        expand_mechanism(
+        let lower_id = if public_arguments.contains_key::<IndexKey>(&"lower".into()) {
+            None
+        } else {
+            maximum_id += 1;
+            Some(maximum_id)
+        };
+
+        let upper_id = if public_arguments.contains_key::<IndexKey>(&"upper".into()) {
+            None
+        } else {
+            maximum_id += 1;
+            Some(maximum_id)
+        };
+
+        let mut expansion = expand_mechanism(
             &SensitivitySpace::KNorm(1),
             privacy_definition,
             self.privacy_usage.as_ref(),
@@ -90,7 +94,32 @@ impl Expandable for proto::SimpleGeometricMechanism {
             properties,
             component_id,
             maximum_id
-        )
+        )?;
+
+        if lower_id.is_some() || upper_id.is_some() {
+            let mut component = expansion.computation_graph.get(&component_id).unwrap().clone();
+
+            let data_property = properties.get::<IndexKey>(&"data".into())
+                .ok_or("data: missing")?.array()?.clone();
+
+            if let Some(lower_id) = lower_id {
+                let (patch_node, release) = get_literal(arr1(&data_property.lower_int()?).into_dyn().into(), component.submission)?;
+                expansion.computation_graph.insert(lower_id, patch_node);
+                expansion.properties.insert(lower_id, infer_property(&release.value, None)?);
+                expansion.releases.insert(lower_id, release);
+                component.insert_argument(&"lower".into(), lower_id);
+            }
+
+            if let Some(upper_id) = upper_id {
+                let (patch_node, release) = get_literal(arr1(&data_property.upper_int()?).into_dyn().into(), component.submission)?;
+                expansion.computation_graph.insert(upper_id, patch_node);
+                expansion.properties.insert(upper_id, infer_property(&release.value, None)?);
+                expansion.releases.insert(upper_id, release);
+                component.insert_argument(&"upper".into(), upper_id);
+            }
+            expansion.computation_graph.insert(component_id, component);
+        }
+        Ok(expansion)
     }
 }
 

--- a/validator-rust/src/components/sum.rs
+++ b/validator-rust/src/components/sum.rs
@@ -38,8 +38,6 @@ impl Component for proto::Sum {
         if data_property.data_type != DataType::Float && data_property.data_type != DataType::Int {
             return Err("data: atomic type must be numeric".into())
         }
-
-        data_property.num_records = Some(1);
         data_property.nature = data_property.num_records.and_then(|n| Some(Nature::Continuous(NatureContinuous {
             lower: match data_property.data_type {
                 DataType::Int => Vector1DNull::Int(data_property
@@ -56,6 +54,7 @@ impl Component for proto::Sum {
                 _ => unreachable!()
             },
         })));
+        data_property.num_records = Some(1);
         data_property.dataset_id = Some(node_id as i64);
 
         Ok(ValueProperties::Array(data_property).into())

--- a/validator-rust/src/components/transforms.rs
+++ b/validator-rust/src/components/transforms.rs
@@ -131,6 +131,7 @@ impl Component for proto::Add {
             is_not_empty: left_property.is_not_empty && right_property.is_not_empty,
             dimensionality: left_property.dimensionality
                 .max(right_property.dimensionality),
+            naturally_ordered: true
         }).into())
     }
 }
@@ -355,6 +356,7 @@ impl Component for proto::Divide {
             is_not_empty: left_property.is_not_empty && right_property.is_not_empty,
             dimensionality: left_property.dimensionality
                 .max(right_property.dimensionality),
+            naturally_ordered: true
         }).into())
     }
 }
@@ -403,7 +405,8 @@ impl Component for proto::Equal {
             dataset_id: left_property.dataset_id,
             is_not_empty: left_property.is_not_empty && right_property.is_not_empty,
             dimensionality: left_property.dimensionality.max(right_property.dimensionality),
-            group_id: propagate_binary_group_id(&left_property, &right_property)?
+            group_id: propagate_binary_group_id(&left_property, &right_property)?,
+            naturally_ordered: true
         }).into())
     }
 }
@@ -460,7 +463,8 @@ impl Component for proto::GreaterThan {
             is_not_empty: left_property.is_not_empty && right_property.is_not_empty,
             dimensionality: left_property.dimensionality
                 .max(right_property.dimensionality),
-            group_id: propagate_binary_group_id(&left_property, &right_property)?
+            group_id: propagate_binary_group_id(&left_property, &right_property)?,
+            naturally_ordered: true
         }).into())
     }
 }
@@ -517,7 +521,8 @@ impl Component for proto::LessThan {
             is_not_empty: left_property.is_not_empty && right_property.is_not_empty,
             dimensionality: left_property.dimensionality
                 .max(right_property.dimensionality),
-            group_id: propagate_binary_group_id(&left_property, &right_property)?
+            group_id: propagate_binary_group_id(&left_property, &right_property)?,
+            naturally_ordered: true
         }).into())
     }
 }
@@ -793,6 +798,7 @@ impl Component for proto::Multiply {
             is_not_empty: left_property.is_not_empty && right_property.is_not_empty,
             dimensionality: left_property.dimensionality
                 .max(right_property.dimensionality),
+            naturally_ordered: true
         }).into())
     }
 }
@@ -1064,6 +1070,7 @@ impl Component for proto::RowMax {
             is_not_empty: left_property.is_not_empty && right_property.is_not_empty,
             dimensionality: left_property.dimensionality
                 .max(right_property.dimensionality),
+            naturally_ordered: true
         }).into())
     }
 }
@@ -1143,6 +1150,7 @@ impl Component for proto::RowMin {
             is_not_empty: left_property.is_not_empty && right_property.is_not_empty,
             dimensionality: left_property.dimensionality
                 .max(right_property.dimensionality),
+            naturally_ordered: true
         }).into())
     }
 }
@@ -1215,6 +1223,7 @@ impl Component for proto::Subtract {
             is_not_empty: left_property.is_not_empty && right_property.is_not_empty,
             dimensionality: left_property.dimensionality
                 .max(right_property.dimensionality),
+            naturally_ordered: true
         }).into())
     }
 }
@@ -1260,6 +1269,10 @@ pub struct OptimizeBinaryOperators<'a> {
 pub fn propagate_binary_shape(left_property: &ArrayProperties, right_property: &ArrayProperties) -> Result<(i64, Option<i64>)> {
     if !left_property.releasable && !right_property.releasable && left_property.group_id != right_property.group_id {
         return Err("data from separate partitions may not be mixed".into())
+    }
+
+    if !left_property.naturally_ordered || !right_property.naturally_ordered {
+        return Err("left or right columns may have been reordered".into())
     }
 
     let left_num_columns = left_property.num_columns()?;

--- a/validator-rust/src/components/union.rs
+++ b/validator-rust/src/components/union.rs
@@ -70,7 +70,8 @@ impl Component for proto::Union {
                 dimensionality: Some(2),
                 group_id: get_group_id_path(array_props.iter()
                     .map(|prop| prop.group_id.clone())
-                    .collect())?
+                    .collect())?,
+                naturally_ordered: false
             })
         } else {
             ValueProperties::Partitions(PartitionsProperties { children: properties })

--- a/validator-rust/src/utilities/inference.rs
+++ b/validator-rust/src/utilities/inference.rs
@@ -248,7 +248,8 @@ pub fn infer_property(
                 dimensionality: Some(array.shape().len() as i64),
                 group_id: prior_prop_arr
                     .map(|v| v.group_id.clone())
-                    .unwrap_or_else(Vec::new)
+                    .unwrap_or_else(Vec::new),
+                naturally_ordered: true
             }.into()
         },
         Value::Dataframe(dataframe) => match prior_property {

--- a/validator-rust/src/utilities/properties.rs
+++ b/validator-rust/src/utilities/properties.rs
@@ -76,6 +76,10 @@ pub fn stack_properties(all_properties: &[ValueProperties], dimensionality: Opti
     let nature = get_common_continuous_nature(&natures, data_type.to_owned())
         .or_else(|| get_common_categorical_nature(&natures));
 
+    if !all_properties.iter().all(|prop| prop.naturally_ordered) {
+        return Err("cannot stack columns that may have been reordered".into())
+    }
+
     Ok(ValueProperties::Array(ArrayProperties {
         num_records,
         num_columns: all_properties.iter()
@@ -91,7 +95,8 @@ pub fn stack_properties(all_properties: &[ValueProperties], dimensionality: Opti
         // this is a library-wide assumption - that datasets have more than zero rows
         is_not_empty: all_properties.iter().all(|prop| prop.is_not_empty),
         dimensionality,
-        group_id
+        group_id,
+        naturally_ordered: true
     }))
 }
 

--- a/validator-rust/src/utilities/serial.rs
+++ b/validator-rust/src/utilities/serial.rs
@@ -265,7 +265,8 @@ pub fn parse_array_properties(value: proto::ArrayProperties) -> ArrayProperties 
         dataset_id: value.dataset_id.and_then(parse_i64_null),
         is_not_empty: value.is_not_empty,
         dimensionality: value.dimensionality.and_then(parse_i64_null),
-        group_id: value.group_id.into_iter().map(parse_group_id).collect()
+        group_id: value.group_id.into_iter().map(parse_group_id).collect(),
+        naturally_ordered: value.naturally_ordered
     }
 }
 
@@ -532,7 +533,7 @@ pub fn serialize_array_properties(value: ArrayProperties) -> proto::ArrayPropert
         num_records, num_columns, nullity, releasable,
         c_stability, aggregator, nature,
         data_type, dataset_id, is_not_empty,
-        dimensionality, group_id
+        dimensionality, group_id, naturally_ordered
     } = value;
 
     proto::ArrayProperties {
@@ -565,7 +566,8 @@ pub fn serialize_array_properties(value: ArrayProperties) -> proto::ArrayPropert
         dataset_id: Some(serialize_i64_null(dataset_id)),
         is_not_empty,
         dimensionality: Some(serialize_i64_null(dimensionality)),
-        group_id: group_id.into_iter().map(serialize_group_id).collect()
+        group_id: group_id.into_iter().map(serialize_group_id).collect(),
+        naturally_ordered
     }
 }
 


### PR DESCRIPTION
In cases where the clamping bounds are numeric, the sensitivity casts numeric bounds to float. This also updates the docs for the lower/upper bound arguments of the simple geometric mechanism, and adds automatic lower/upper bound inference in cases where lower/upper may be statically determined via the properties.

In the future, we should represent sensitivity as integers when possible.


EDIT: Added a fix for the base in the exponential mechanism.
EDIT: Added checking for natural ordering to block binary+ transforms after a union.