### PR TITLE
deprecate SmartNoise-Core

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,8 @@
+**Notice**: SmartNoise-Core is deprecated. Please migrate to the OpenDP library:
+- [OpenDP Rust Crate](https://crates.io/crates/opendp)
+- [OpenDP GitHub Repo](https://github.com/opendp/opendp/)
+
+----------------------------------------------------
 
 [![.github/workflows/rust.yml](https://github.com/opendp/smartnoise-core/actions/workflows/rust.yml/badge.svg)](https://github.com/opendp/smartnoise-core/actions/workflows/rust.yml) 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)

--- a/ffi-rust/Cargo.toml
+++ b/ffi-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "smartnoise_ffi"
-version = "0.2.2"
+version = "0.2.3"
 authors = ["OpenDP-SmartNoise <smartnoise@opendp.org>"]
 description = "A wrapper library for interfacing with the SmartNoise over ffi."
 readme = "README.md"
@@ -9,6 +9,9 @@ categories = ["cryptography", "science"] # up to 5 allowed, must match those lis
 repository = "https://github.com/opendp/smartnoise-core"
 edition = "2018"
 license = "MIT"
+
+[badges]
+maintenance = {status = "deprecated"}
 
 [dependencies]
 prost = "0.6.1"

--- a/ffi-rust/README.md
+++ b/ffi-rust/README.md
@@ -1,3 +1,8 @@
+**Notice**: SmartNoise-Core is deprecated. Please migrate to the OpenDP library:
+- [OpenDP Rust Crate](https://crates.io/crates/opendp)
+- [OpenDP GitHub Repo](https://github.com/opendp/opendp/)
+
+----------------------------------------------------
 
 ## SmartNoise Core <br/> Differential Privacy Library FFI <br/>
 

--- a/runtime-rust/Cargo.toml
+++ b/runtime-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "smartnoise_runtime"
-version = "0.2.2"
+version = "0.2.3"
 authors = ["OpenDP-SmartNoise <smartnoise@opendp.org>"]
 description = "A library of algorithms for differentially private data analysis."
 readme = "README.md"
@@ -9,6 +9,9 @@ categories = ["cryptography", "science"] # up to 5 allowed, must match those lis
 repository = "https://github.com/opendp/smartnoise-core"
 edition = "2018"
 license = "MIT"
+
+[badges]
+maintenance = {status = "deprecated"}
 
 [dependencies]
 probability = "0.17.0"

--- a/runtime-rust/README.md
+++ b/runtime-rust/README.md
@@ -1,3 +1,9 @@
+**Notice**: SmartNoise-Core is deprecated. Please migrate to the OpenDP library:
+- [OpenDP Rust Crate](https://crates.io/crates/opendp)
+- [OpenDP GitHub Repo](https://github.com/opendp/opendp/)
+
+----------------------------------------------------
+
 ## SmartNoise Core: Differential Privacy Library Runtime
 
 This runtime is a sub-project of [SmartNoise-Core](https://github.com/opendp/smartnoise-core).

--- a/validator-rust/Cargo.toml
+++ b/validator-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "smartnoise_validator"
-version = "0.2.2"
+version = "0.2.3"
 authors = ["OpenDP-SmartNoise <smartnoise@opendp.org>"]
 description = "A library for validating whether or not an analysis is differentially private."
 readme = "README.md"
@@ -10,6 +10,9 @@ repository = "https://github.com/opendp/smartnoise-core"
 build = "build/main.rs"
 edition = "2018"
 license = "MIT"
+
+[badges]
+maintenance = {status = "deprecated"}
 
 [dependencies]
 prost = "0.6.1"

--- a/validator-rust/README.md
+++ b/validator-rust/README.md
@@ -1,3 +1,8 @@
+**Notice**: SmartNoise-Core is deprecated. Please migrate to the OpenDP library:
+- [OpenDP Rust Crate](https://crates.io/crates/opendp)
+- [OpenDP GitHub Repo](https://github.com/opendp/opendp/)
+
+----------------------------------------------------
 
 ## SmartNoise Core: Differential Privacy Library Validator 
 


### PR DESCRIPTION
Closes #363.

**Notice**: SmartNoise-Core is deprecated. Please migrate to the OpenDP library:
- [OpenDP PyPi Package](https://pypi.org/project/opendp/)
- [OpenDP GitHub Repo](https://github.com/opendp/opendp/)
