### PR TITLE
deprecate SmartNoise-Core: synchronize version

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,3 +1,7 @@
+### v0.2.3
+* Deprecated SmartNoise-Core
+* Please migrate to the OpenDP library: docs.opendp.org/
+
 ### v0.2.2
 * Custom sensitivities may be passed directly to mechanisms
     - `protect_sensitivity` must be disabled in the privacy definition

--- a/ffi-rust/Cargo.toml
+++ b/ffi-rust/Cargo.toml
@@ -19,12 +19,12 @@ ffi-support = "0.4.0"
 indexmap = "1.4.0"
 
 [dependencies.smartnoise_validator]
-path = "../validator-rust/"
-version = "0.2.2"
+path = "../validator-rust"
+version = "0.2.3"
 
 [dependencies.smartnoise_runtime]
-path = "../runtime-rust/"
-version = "0.2.2"
+path = "../runtime-rust"
+version = "0.2.3"
 optional = true
 default-features = false
 

--- a/runtime-rust/Cargo.toml
+++ b/runtime-rust/Cargo.toml
@@ -43,8 +43,8 @@ statrs = "0.12.0"
     optional = true
 
     [dependencies.smartnoise_validator]
-    version = "0.2.2"
-    path = "../validator-rust/"
+    version = "0.2.3"
+    path = "../validator-rust"
 
 [features]
 default = ["use-mpfr"]


### PR DESCRIPTION
Closes #363. Synchronizes version number to 0.2.3.

**Notice**: SmartNoise-Core is deprecated. Please migrate to the OpenDP library:
- [OpenDP Rust Crate](https://crates.io/crates/opendp)
- [OpenDP GitHub Repo](https://github.com/opendp/opendp/)
